### PR TITLE
feat(logger) Create Simple CLI Logger

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,4 +101,5 @@ Aurelia.prototype.run = function(argv) {
   program.parse(argv);
 };
 
+
 module.exports = Aurelia;

--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -17,7 +17,10 @@ var prefix = {
     , ok     : 'OK'.green
 };
 
-module.exports.log = log = function(){
+// log
+// color   magenta
+// prefix [aurelia]:
+function log(){
   var args = Array.prototype.slice.call(arguments).slice(1);
   args.unshift(prefix.aurelia)
   var template = '[%s] ' + arguments[0];
@@ -25,7 +28,10 @@ module.exports.log = log = function(){
   console.log.apply(console, args);
 }
 
-module.exports.err = function(){
+// err
+// color red
+// prefix [aurelia] [Error]:
+function err(){
   var args = Array.prototype.slice.call(arguments).slice(1);
   args.unshift(prefix.err)
   args.unshift(prefix.aurelia)
@@ -33,10 +39,11 @@ module.exports.err = function(){
   args.unshift(template)
   console.log.apply(console, args);
 }
-module.exports.error = module.exports.err
 
-
-module.exports.ok  = function(){
+// ok
+// color green
+// prefix [aurelia] [OK]:
+function ok(){
   var args = Array.prototype.slice.call(arguments).slice(1);
   args.unshift(prefix.ok)
   args.unshift(prefix.aurelia)
@@ -44,5 +51,12 @@ module.exports.ok  = function(){
   args.unshift(template)
   console.log.apply(console, args);
 }
-module.exports.success = module.exports.ok
 
+// Use aliases as some like to use more readable methods, like "success" over "ok"
+module.exports = {
+  ok:ok,
+  log:log,
+  err:err,
+  error:err,
+  success:ok,
+}

--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -1,0 +1,48 @@
+
+Object.defineProperties(String.prototype, {
+  magenta: { get: function(){ return '\x1B[35m' + this.valueOf() + '\x1B[39m'; } },
+  yellow:  { get: function(){ return '\x1B[33m' + this.valueOf() + '\x1B[39m'; } },
+  white:   { get: function(){ return '\x1B[37m' + this.valueOf() + '\x1B[39m'; } },
+  black:   { get: function(){ return '\x1B[30m' + this.valueOf() + '\x1B[39m'; } },
+  green:   { get: function(){ return '\x1B[32m' + this.valueOf() + '\x1B[39m'; } },
+  grey:    { get: function(){ return '\x1B[90m' + this.valueOf() + '\x1B[39m'; } },
+  blue:    { get: function(){ return '\x1B[34m' + this.valueOf() + '\x1B[39m'; } },
+  cyan:    { get: function(){ return '\x1B[36m' + this.valueOf() + '\x1B[39m'; } },
+  red:     { get: function(){ return '\x1B[31m' + this.valueOf() + '\x1B[39m'; } },
+});
+
+var prefix = {
+      aurelia: 'aurelia'.magenta
+    , err    : 'Error'.red
+    , ok     : 'OK'.green
+};
+
+module.exports.log = log = function(){
+  var args = Array.prototype.slice.call(arguments).slice(1);
+  args.unshift(prefix.aurelia)
+  var template = '[%s] ' + arguments[0];
+  args.unshift(template)
+  console.log.apply(console, args);
+}
+
+module.exports.err = function(){
+  var args = Array.prototype.slice.call(arguments).slice(1);
+  args.unshift(prefix.err)
+  args.unshift(prefix.aurelia)
+  var template = '[%s] [%s]: ' + arguments[0];
+  args.unshift(template)
+  console.log.apply(console, args);
+}
+module.exports.error = module.exports.err
+
+
+module.exports.ok  = function(){
+  var args = Array.prototype.slice.call(arguments).slice(1);
+  args.unshift(prefix.ok)
+  args.unshift(prefix.aurelia)
+  var template = '[%s] [%s]: ' + arguments[0];
+  args.unshift(template)
+  console.log.apply(console, args);
+}
+module.exports.success = module.exports.ok
+


### PR DESCRIPTION
This feature resolves the feature request #11  

Using this simple logger, you can simply require `lib/logger` and use it in one of the three ways. 

```
logger.log('Something') -> [aurelia]: somthing
logger.err('some error') -> [aurelia] [Error]: some error
logger.ok('good to go') -> [aurelia] [Success]: good to go

```
