### PR TITLE
feat(built in command): dynamically load all the built in commands.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,7 @@
 import program from 'commander';
-import glob from 'glob';
 import logger from 'winston';
-
-import BundleCommand from './commands/bundle';
-import InitCommand from './commands/init';
-import NewCommand from './commands/new';
-import GenerateCommand from './commands/generate';
+import fs from 'fs';
+import path from 'path';
 
 class Aurelia {
   constructor() {
@@ -17,16 +13,14 @@ class Aurelia {
 
   init(config) {
     this.config = config;
-    let bundle = new BundleCommand(program, this.config, this.logger);
-    let init = new InitCommand(program, this.config, this.logger);
-    let newCmd = new NewCommand(program, this.config, this.logger);
-    let generateCmd = new GenerateCommand(program, this.config, this.logger);
 
-    this.commands[bundle.commandId] = bundle;
-    this.commands[init.commandId] = init;
-    this.commands[newCmd.commandId] = newCmd;
-    this.commands[generateCmd.commandId] = generateCmd;
-
+    var cmdDir = __dirname + path.sep + 'commands';
+    fs.readdirSync(cmdDir)
+      .forEach((f) => {
+        var Cmd = require(cmdDir + path.sep + f);
+        let c = new Cmd(program, this.config, this.logger);
+        this.commands[c.commandId] = c;
+      });
   }
 
   command(...args) {


### PR DESCRIPTION
After authoring every new built in command we change `src/index` to add the following lines of code.

```javascript
import BuiltInCommand from './commands/newcommand';


    let cmd = new BuiltinCommand(program, this.config, this.logger);
    
    this.commands[cmd.commandId] = cmd;
```

Well with this PR we don't have to touch the file for new commands. As long as they are placed in `commads` folder they will be auto discovered, instantiated and registered to the core.

Every thing should work as it is. No breaking change should be introduced by the PR. Please test it on your machine after review. If you give it a go we will then merge.  
