### PR TITLE
feat(aurelia-command): Add New Command API for aurelia-commands

### DIFF
--- a/bin/aurelia.js
+++ b/bin/aurelia.js
@@ -3,7 +3,9 @@
 var Liftoff = require('liftoff');
 var argv = require('minimist')(process.argv.slice(2));
 var logger = require('winston');
-
+process.AURELIA = {
+  argv:argv
+};
 process.env.INIT_CWD = process.cwd();
 var DEV_ENV = parseInt(process.env.AURELIA_CLI_DEV_ENV, 10);
 
@@ -28,8 +30,14 @@ cli.on('require', function(name) {
 });
 
 if (DEV_ENV) {
-  require("babel/register");
-} 
+  require("babel/register")({
+    modules: 'common',
+    optional: [
+      "es7.decorators",
+      "es7.classProperties"
+    ]
+  });
+}
 
 cli.launch({
   cwd: argv.cwd,
@@ -68,6 +76,6 @@ function handleCommands(env) {
   }
 
   process.nextTick(function() {
-    aurelia.run(process.argv);
+    aurelia.run(argv);
   });
 }

--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
     "url": "https://github.com/aurelia/cli"
   },
   "dependencies": {
+    "aurelia-command": "file:../aurelia-command",
     "bluebird": "^2.9.25",
     "chalk": "^1.0.0",
     "commander": "^2.8.1",
     "download-github-repo": "^0.1.3",
     "github": "^0.2.4",
     "glob": "^5.0.9",
+    "handlebars": "^3.0.3",
     "inquirer": "^0.8.5",
     "jspm": "^0.15.6",
     "liftoff": "^2.1.0",
@@ -41,8 +43,7 @@
     "mkdirp": "^0.5.1",
     "npm": "^2.10.1",
     "whacko": "^0.18.1",
-    "winston": "^1.0.0",
-    "handlebars": "^3.0.3"
+    "winston": "^1.0.0"
   },
   "devDependencies": {
     "babel": "^5.4.7",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/aurelia/cli"
   },
   "dependencies": {
-    "aurelia-command": "file:../aurelia-command",
+    "aurelia-command": "^0.1.1",
     "bluebird": "^2.9.25",
     "chalk": "^1.0.0",
     "commander": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/aurelia/cli"
   },
   "dependencies": {
-    "aurelia-command": "^0.1.1",
+    "aurelia-command": "^0.1.2",
     "bluebird": "^2.9.25",
     "chalk": "^1.0.0",
     "commander": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/aurelia/cli"
   },
   "dependencies": {
-    "aurelia-command": "^0.1.2",
+    "aurelia-command": "^0.1.3",
     "bluebird": "^2.9.25",
     "chalk": "^1.0.0",
     "commander": "^2.8.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
-import program from 'commander';
 import glob from 'glob';
 import logger from 'winston';
-
+import program from 'aurelia-command';
 import BundleCommand from './commands/bundle';
 import InitCommand from './commands/init';
 import NewCommand from './commands/new';
@@ -17,38 +16,32 @@ class Aurelia {
 
   init(config) {
     this.config = config;
-    let bundle = new BundleCommand(program, this.config, this.logger);
-    let init = new InitCommand(program, this.config, this.logger);
-    let newCmd = new NewCommand(program, this.config, this.logger);
-    let generateCmd = new GenerateCommand(program, this.config, this.logger);
-
-    this.commands[bundle.commandId] = bundle;
-    this.commands[init.commandId] = init;
-    this.commands[newCmd.commandId] = newCmd;
-    this.commands[generateCmd.commandId] = generateCmd;
-
+    program.init(config);
+    program.register(BundleCommand);
+    program.register(InitCommand);
+    program.register(NewCommand);
+    program.register(GenerateCommand);
   }
 
-  command(...args) {
-    if (typeof args[0] === 'string') {
-      let commandId = args[0];
-      let config = args[1];
-      this.commands[commandId].commandConfig = config;
+  command(commandId, Construction) {
+    if (typeof commandId === 'function') {
+      Construction = commandId;
+      commandId = null;
+    }
+
+    if (commandId && typeof Construction === 'object') {
+      this.program.commands[commandId].commandConfig = Construction;
       return;
     }
 
-    if (typeof args[0] === 'function') {
-      let Cmd = args[0];
-      let commandConfig = args[1];
-      let c = new Cmd(program, this.config, this.logger);
-      c.commandConfig = commandConfig;
-      this.commands[c.commandId] = c;
+    if (typeof Construction === 'function') {
+      program.register(Construction);
       return;
     }
   }
 
   run(argv) {
-    program.parse(argv);
+    program.start(argv);
   }
 }
 


### PR DESCRIPTION
This PR replaces commanderjs with aurelia-command.

I have also modified the `aurelia.init()` and `aurelia.command()` from `src/index.js`

I have also placed `argv` on `process.AURELIA`
