### PR TITLE
feat(bundler): allow specifying baseURL manually

### DIFF
--- a/src/lib/bundler.js
+++ b/src/lib/bundler.js
@@ -14,7 +14,7 @@ function bundleJS(moduleExpression, outfile, options) {
 export default function bundle(config, bundleOpts) {
 
   var loader = api.Builder().loader;
-  var baseURL = loader.baseURL;
+  var baseURL = bundleOpts.baseURL || loader.baseURL;
   var paths = loader.paths;
   var cleanBaseURL = baseURL.replace(/^file:/, '');
 


### PR DESCRIPTION
I haven't tried it yet but it looks like its the only change needed to be able to specify the baseURL for the bundler.
fixes #132