### PR TITLE
Specify moduleName without version in aureliafile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,29 @@ aurelia bundle
   - `paths` are important to consider when specifying `module names` 
 
 ### Template bundle option
-- Option
-  - *inject:* injects a `<link aurelia-view-bundle rel="import" href="bundle_name.html">` at the end of the body tag of  `index.html` to include the bundle file.
 
-- Note:
+#### Options
+  - *inject:* injects a `<link aurelia-view-bundle rel="import" href="bundle_name.html">` at the end of the body tag of  `index.html` to include the bundle file.
+  - *inject* can be an object too. 
+
+```javascript
+  template: {
+    "dist/app-bundle": {
+      pattern: 'dist/*.html',
+      options: {
+        inject: {
+          indexFile: 'index.html',
+          destFile: 'dist/index.html'
+        },
+      }
+    }
+  }
+```
+  - *indexFile* : Path of the `index.html` relative to baseURL. If not specified default is `baseURL/index.html`.
+  - *destFile* :  Path of the new html file with the injected link. When not specified defaults to `indexFile`.
+  
+#### Note:
+
   - Globs template relative to `baseURL`
   - Glob files. 
   - Multiple glob pattern can be specified as `['dist/about/*.html', 'other/**/*.html']`

--- a/bin/aurelia.js
+++ b/bin/aurelia.js
@@ -32,7 +32,8 @@ if (DEV_ENV) {
     modules: 'common',
     optional: [
       "es7.decorators",
-      "es7.classProperties"
+      "es7.classProperties",
+      "runtime"
     ]
   });
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,8 @@ gulp.task('copy-source', function() {
       stage:2,
       optional: [
         "es7.decorators",
-        "es7.classProperties"
+        "es7.classProperties",
+        "runtime"
       ]
     }))
     .pipe(gulp.dest('dist'));

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "babel": "^5.4.7",
+    "babel-runtime": "^5.8.19",
     "chai": "^2.3.0",
     "gulp": "^3.8.11",
     "gulp-babel": "^5.1.0",

--- a/src/lib/bundler/index.js
+++ b/src/lib/bundler/index.js
@@ -13,9 +13,8 @@ export default function bundle(config, bundleOpts) {
     .forEach(key  => {
       let cfg = jsConfig[key];
       let outfile = key + '.js';
-      let moduleExpr = cfg.modules.join(' + ');
       let opt = cfg.options;
-      bundleJS(moduleExpr, outfile, opt, bundleOpts);
+      bundleJS(cfg.modules, outfile, opt, bundleOpts);
     });
 
   if (!templateConfig) return;
@@ -29,3 +28,4 @@ export default function bundle(config, bundleOpts) {
       bundleTemplate(pattern, outfile, opt, bundleOpts);
     });
 }
+

--- a/src/lib/bundler/js-bundler.js
+++ b/src/lib/bundler/js-bundler.js
@@ -10,7 +10,10 @@ import path from 'path';
 ui.setResolver(this);
 ui.useDefaults();
 
-export function bundleJS(moduleExpression, fileName, opts, bundleOpts) {
+export function bundleJS(modules, fileName, opts, bundleOpts) {
+
+  var moduleExpression = modules.map(m => getFullModuleName(m)).join(' + ');
+
   jspm.setPackagePath('.');
   var customCfg = {} // pass all sort of custom configuration like baseURL etc here.
   var builder = new jspm.Builder(customCfg);
@@ -80,4 +83,8 @@ function logBuild(outFile, opts) {
     (opts.sourceMaps ? ' with ' + resolution + 'source maps' : '') + ', ' +
     (opts.minify ? '' : 'un') + 'minified' +
     (opts.minify ? (opts.mangle ? ', ' : ', un') + 'mangled.' : '.'));
+}
+
+function getFullModuleName(moduleName){
+  return moduleName;
 }

--- a/src/lib/bundler/js-bundler.js
+++ b/src/lib/bundler/js-bundler.js
@@ -32,7 +32,6 @@ export function bundleJS(modules, fileName, opts, bundleOpts) {
 
   var moduleExpression = modules.map(m => getFullModuleName(m, config.loader.__originalConfig.map)).join(' + ');
 
-  console.log(moduleExpression);
   return builder.trace(moduleExpression)
     .then(function(buildTree) {
       logTree(buildTree);
@@ -109,9 +108,9 @@ function getFullModuleName(moduleName, map) {
   }
 
   if (matches.length > 1) {
-    ui.log('err', `Multiple mathces found for module: '${moduleName}'. Matches are:`);
+    ui.log('err', `Multiple matches found for module: '${moduleName}'. Matches are:`);
     logModules(matches);
-    ui.log('info', `Try including specific version number. Or, resolve the conflict with manually with 'jspm'`);
+    ui.log('info', 'Try including a specific version number or resolve the conflict manually with jspm');
     throw 'Version conflict found in module names specified in `aureliafile`';
   }
 

--- a/src/lib/bundler/template-bundler.js
+++ b/src/lib/bundler/template-bundler.js
@@ -42,15 +42,16 @@ export function bundleTemplate(pattern, fileName, options, bundleOpts) {
   fs.writeFileSync(outfile, templates.join('\n'));
 
   if (options.inject) {
-    injectLink(outfile, utils.fromFileURL(baseURL));
+    injectLink(outfile, utils.fromFileURL(baseURL), options.inject.indexFile);
   }
 }
 
 
-function injectLink(outfile, baseURL) {
+function injectLink(outfile, baseURL, fileName) {
   var link = '';
   var bundle = path.resolve(baseURL, path.relative(baseURL, outfile));
-  var index = path.resolve(baseURL, 'index.html');
+
+  var index = path.resolve(baseURL, fileName || 'index.html');
   var relpath = path.relative(path.dirname(index), path.dirname(bundle)).replace(/\\/g, '/');
 
   if (!relpath.startsWith('.')) {

--- a/src/lib/bundler/template-bundler.js
+++ b/src/lib/bundler/template-bundler.js
@@ -53,8 +53,7 @@ function injectLink(outfile, baseURL) {
   var index = path.resolve(baseURL, 'index.html');
   var relpath = path.relative(path.dirname(index), path.dirname(bundle)).replace(/\\/g, '/');
 
-  //regex : !link.startsWith('.')
-  if (!(/^\./.test(relpath))) {
+  if (!relpath.startsWith('.')) {
     link = relpath ? './' + relpath + '/' + path.basename(bundle) : './' + path.basename(bundle);
   } else {
     link = relpath + '/' + path.basename(bundle);

--- a/src/lib/bundler/template-bundler.js
+++ b/src/lib/bundler/template-bundler.js
@@ -42,16 +42,18 @@ export function bundleTemplate(pattern, fileName, options, bundleOpts) {
   fs.writeFileSync(outfile, templates.join('\n'));
 
   if (options.inject) {
-    injectLink(outfile, utils.fromFileURL(baseURL), options.inject.indexFile);
+    injectLink(outfile, utils.fromFileURL(baseURL), options.inject);
   }
 }
 
 
-function injectLink(outfile, baseURL, fileName) {
+function injectLink(outfile, baseURL, injectOptions) {
   var link = '';
+  var fileName = injectOptions.indexFile;
   var bundle = path.resolve(baseURL, path.relative(baseURL, outfile));
-
   var index = path.resolve(baseURL, fileName || 'index.html');
+  var destFile = injectOptions.destFile ? path.resolve(baseURL, injectOptions.destFile) : index;
+
   var relpath = path.relative(path.dirname(index), path.dirname(bundle)).replace(/\\/g, '/');
 
   if (!relpath.startsWith('.')) {
@@ -70,7 +72,7 @@ function injectLink(outfile, baseURL, fileName) {
     $('body').append('<link aurelia-view-bundle rel="import" href="' + link + '">');
   }
 
-  fs.writeFileSync(index, $.html());
+  fs.writeFileSync(destFile, $.html());
 }
 
 function getCanonicalName(builder, file, pluginName) {


### PR DESCRIPTION
As of now, we are directly using `systemjs-builder` for bundling js modules. For `systemjs-builder` a module is not just it's name rather it's `name + version`. So, a valid module name would look like: `github:aurelia/templating-binding@0.12.0`. When we create the `aurliafile` configuration for bundling js modules, we specify both (name + version). This creates a maintenance issue. Whenever we update the project dependencies, we potentially invalidate the `aureliafile` as update tend to change the version number.  To solve this issue, we need to specify the configuration without the version number and internally develop a lookup mechanism for resolving correct moduleName with version from `config.js` for `systemjs-builder`.

One detail to remember is that if we find multiple versions where one is not specified in the aureliafile, we should throw an exception. The exception message should be clear about that is happening and recommend the possible solution of running `jspm clean` to remove old versions.

Work in progress.
@EisenbergEffect 