### PR TITLE
unbundle command

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "inquirer": "^0.8.5",
     "jspm": "git://github.com/jspm/jspm-cli#master",
     "liftoff": "^2.1.0",
-    "lodash": "^3.9.1",
+    "lodash": "^3.10.1",
     "minimist": "^1.1.1",
     "mkdirp": "^0.5.1",
     "npm": "^2.10.1",
-    "systemjs-builder": "git://github.com/systemjs/builder#master",
+    "systemjs-builder": "^0.13.0",
     "whacko": "^0.18.1",
     "winston": "^1.0.0"
   },

--- a/src/commands/bundle/index.js
+++ b/src/commands/bundle/index.js
@@ -4,18 +4,15 @@ import {command, alias, option, description} from '../../decorators';
 @command('bundle')
 @alias('b')
 @description('Create a new bundle based on the configuration in Aureliafile.js')
-@option('-a --add <path>', "Add system.js path to files or file to bundle")
-@option('-r --remove <remove_path>', 'Remove file path or file from bundle')
-@option('-l, --list', 'List paths and files included in bundle')
-@option('-f, --force', 'Overwrite output file!')
+@option('-f, --force', 'Overwrite previous bundle output file.')
 export default class BundleCommand {
   constructor(config, logger) {
     this.config = config;
     this.logger = logger;
   }
 
-   action(options)  {
-     this.logger.info('Creating bundle ...');
-     bundle(this.commandConfig, options);
-   };
+  action(options)  {
+   this.logger.info('Creating bundle ...');
+   bundle(this.commandConfig, options);
+  };
 }

--- a/src/commands/unbundle.js
+++ b/src/commands/unbundle.js
@@ -1,0 +1,15 @@
+import { description, command, args, option } from '../decorators';
+
+
+@command('unbundle')
+@option('-c, --clear-invalids', 'Only clear the invalid bundle injections')
+@description('Unbundles based on bundle config in Aureliafile')
+export default class InitCommand {
+  constructor(config, logger) {
+    this.config = config;
+  }
+
+  action(opt) {
+    console.log('Un bundling ... ');
+  }
+}

--- a/src/commands/unbundle.js
+++ b/src/commands/unbundle.js
@@ -1,9 +1,11 @@
-import { description, command, args, option } from '../decorators';
+import { description, command, args, option, alias } from '../decorators';
 import {unbundle} from '../lib/unbundler';
+import _ from 'lodash';
 
 
 @command('unbundle')
-@option('-c, --clear-invalids', 'Only clear the invalid bundle injections')
+@alias('u')
+@option('-r, --remove-files', 'Remove bundle files.')
 @description('Unbundles based on bundle config in Aureliafile')
 export default class InitCommand {
   constructor(config, logger) {
@@ -12,10 +14,19 @@ export default class InitCommand {
   }
 
   action(opt) {
+
+    let otherOpts = {
+       clearInvalids : opt.clearInvalids || false,
+       removeFiles : opt.removeFiles || false
+    };
+
+    let options = _.defaults(this.commandConfig, otherOpts);
+
     this.logger.info('Un bundling ... ');
-    unbundle()
+
+    unbundle(options)
       .then(() => {
-         this.logger.info('Bundle configuration removed ...');
+         this.logger.info('Bundle configuration removed! ...');
       });
   }
 }

--- a/src/commands/unbundle.js
+++ b/src/commands/unbundle.js
@@ -1,4 +1,5 @@
 import { description, command, args, option } from '../decorators';
+import {unbundle} from '../lib/unbundler';
 
 
 @command('unbundle')
@@ -7,9 +8,14 @@ import { description, command, args, option } from '../decorators';
 export default class InitCommand {
   constructor(config, logger) {
     this.config = config;
+    this.logger = logger;
   }
 
   action(opt) {
-    console.log('Un bundling ... ');
+    this.logger.info('Un bundling ... ');
+    unbundle()
+      .then(() => {
+         this.logger.info('Bundle configuration removed ...');
+      });
   }
 }

--- a/src/lib/bundler/index.js
+++ b/src/lib/bundler/index.js
@@ -1,10 +1,6 @@
 import { bundleJS } from './js-bundler';
 import { bundleTemplate } from './template-bundler';
 
-// before calling any jspm api we should call the function bellow to set custom package path.
-// jspm.setPackagePath('.');
-// do we want to set custom set package path or baseURL? need discussion with @EisenbergEffect
-
 export default function bundle(config, bundleOpts) {
   var jsConfig = config.js;
   var templateConfig = config.template;

--- a/src/lib/bundler/js-bundler.js
+++ b/src/lib/bundler/js-bundler.js
@@ -31,7 +31,8 @@ export function bundleJS(modules, fileName, opts, bundleOpts) {
 
   var moduleExpression = modules.map(m => getFullModuleName(m, config.loader.__originalConfig.map)).join(' + ');
 
-  return builder.trace(moduleExpression)
+  return builder
+    .trace(moduleExpression)
     .then(function(buildTree) {
       logTree(buildTree);
       if (!('lowResSourceMaps' in opts))
@@ -44,7 +45,7 @@ export function bundleJS(modules, fileName, opts, bundleOpts) {
     })
     .then(config.save)
     .then(function() {
-      logBuild(path.relative(process.cwd(), fileName), opts);
+      logBuild(outfile, opts);
     })
     .catch(function(e) {
       ui.log('err', e.stack || e);

--- a/src/lib/bundler/js-bundler.js
+++ b/src/lib/bundler/js-bundler.js
@@ -7,10 +7,9 @@ import Promise from 'bluebird';
 import { toFileURL, fromFileURL } from 'systemjs-builder/lib/utils';
 import path from 'path';
 
-ui.setResolver(this);
-ui.useDefaults();
-
 export function bundleJS(modules, fileName, opts, bundleOpts) {
+  ui.setResolver(this);
+  ui.useDefaults();
 
   jspm.setPackagePath('.');
   var customCfg = {} // pass all sort of custom configuration like baseURL etc here.

--- a/src/lib/unbundler.js
+++ b/src/lib/unbundler.js
@@ -1,5 +1,41 @@
 import jspm from 'jspm';
+import Promise from 'bluebird';
+import whacko from 'whacko';
 
-export function unbundle(){
-  return jspm.unbundle();
+export function unbundle(opts) {
+
+  var packagePath = opts.packagePath || '.';
+  jspm.setPackagePath(opts.packagePath);
+
+  var tasks = [jspm.unbundle(), unbundleTemplate(opts)];
+
+  return Promise.all(tasks)
+    .then(() => {
+      console.log('Unbundle completed!');
+    });
+}
+
+function removeTemplateInjection(opts) {
+  var file =  // get normalized path of the index.html relative to baseURL;
+  return Promise
+    .promisify(fs.readFile)(file, {
+      encoding: utf8
+    })
+    .then((content) => {
+      return Promise.resolve(whacko.load(content));
+    })
+    .then(removeInvalidLinks($))
+    .then(removeLinkInjections($))
+}
+
+function removeInvalidLinks($) {
+  // search all the links with `aurelia-view-bundle` in `index.html`
+  // complare with aureliafile's bundle config.
+  // find the invalid links from the comparisn
+  // remove them from the DOM
+  // return promise with clean DOM.
+}
+
+function removeLinkInjection() {
+
 }

--- a/src/lib/unbundler.js
+++ b/src/lib/unbundler.js
@@ -1,0 +1,5 @@
+import jspm from 'jspm';
+
+export function unbundle(){
+  return jspm.unbundle();
+}

--- a/src/lib/unbundler.js
+++ b/src/lib/unbundler.js
@@ -7,16 +7,19 @@ export function unbundle(opts) {
   var packagePath = opts.packagePath || '.';
   jspm.setPackagePath(opts.packagePath);
 
-  var tasks = [jspm.unbundle(), unbundleTemplate(opts)];
-
+  var tasks = [removeJSBundle(opts), removeTemplateBundle(opts)];
   return Promise.all(tasks)
     .then(() => {
       console.log('Unbundle completed!');
     });
 }
 
-function removeTemplateInjection(opts) {
-  var file =  // get normalized path of the index.html relative to baseURL;
+function removeJsBundle(opts) {
+  return jspm.unbundle();
+}
+
+function removeTemplateBundle(opts) {
+  var file = '';  // get normalized path of the index.html relative to baseURL;
   return Promise
     .promisify(fs.readFile)(file, {
       encoding: utf8
@@ -24,8 +27,12 @@ function removeTemplateInjection(opts) {
     .then((content) => {
       return Promise.resolve(whacko.load(content));
     })
-    .then(removeInvalidLinks($))
-    .then(removeLinkInjections($))
+    .then(($)=> { 
+      return removeInvalidLinks($)
+    })
+    .then(($) => {
+      return removeLinkInjections($)
+    });
 }
 
 function removeInvalidLinks($) {


### PR DESCRIPTION
Unbundle any current bundle and remove all bundle js injections from `config.js` and `aurelia-view-bundle` `index` html file.

- The command should respect the new [destFile](https://github.com/aurelia/cli#template-bundle-option) setting for `template` bundle.  
- It should also clear the obsolete injections as well.