### PR TITLE
Robust View Bundling - Following SystemJS Injection Pattern

### DIFF
--- a/src/lib/bundler/template-bundler.js
+++ b/src/lib/bundler/template-bundler.js
@@ -7,11 +7,11 @@ import globby from 'globby';
 import utils from 'systemjs-builder/lib/utils';
 
 export function bundleTemplate(pattern, fileName, options, bundleOpts) {
-  var templates = [];
-  var builder = new jspm.Builder();
-  var baseURL = builder.loader.baseURL;
-  var cwd = utils.fromFileURL(baseURL);;
-  var outfile = path.resolve(utils.fromFileURL(baseURL), fileName);
+  let templates = [];
+  let builder = new jspm.Builder();
+  let baseURL = builder.loader.baseURL;
+  let cwd = utils.fromFileURL(baseURL);;
+  let outfile = path.resolve(utils.fromFileURL(baseURL), fileName);
 
   if (fs.existsSync(outfile)) {
     if (!bundleOpts.force) {
@@ -25,14 +25,14 @@ export function bundleTemplate(pattern, fileName, options, bundleOpts) {
     .sync(pattern, {
       cwd: cwd.replace(/\\/g, '/')
     })
-    .forEach(function(file) {
+    .forEach((file) => {
       file = path.resolve(cwd, file);
-      var content = fs.readFileSync(file, {
+      let content = fs.readFileSync(file, {
         encoding: 'utf8'
       });
 
-      var $ = whacko.load(content);
-      var name = getCanonicalName(builder, file, 'view');
+      let $ = whacko.load(content);
+      let name = getCanonicalName(builder, file, 'view');
 
       $('template').attr('id', name);
       var template = $.html('template');
@@ -42,37 +42,17 @@ export function bundleTemplate(pattern, fileName, options, bundleOpts) {
   fs.writeFileSync(outfile, templates.join('\n'));
 
   if (options.inject) {
-    injectLink(outfile, utils.fromFileURL(baseURL), options.inject);
+    inject(outfile, utils.fromFileURL(baseURL), options.inject);
   }
 }
 
 
-function injectLink(outfile, baseURL, injectOptions) {
-  var link = '';
-  var fileName = injectOptions.indexFile;
-  var bundle = path.resolve(baseURL, path.relative(baseURL, outfile));
-  var index = path.resolve(baseURL, fileName || 'index.html');
-  var destFile = injectOptions.destFile ? path.resolve(baseURL, injectOptions.destFile) : index;
-
-  var relpath = path.relative(path.dirname(index), path.dirname(bundle)).replace(/\\/g, '/');
-
-  if (!relpath.startsWith('.')) {
-    link = relpath ? './' + relpath + '/' + path.basename(bundle) : './' + path.basename(bundle);
-  } else {
-    link = relpath + '/' + path.basename(bundle);
-  }
-
-  var content = fs.readFileSync(index, {
-    encoding: 'utf8'
-  });
-
-  var $ = whacko.load(content);
-
-  if ($('link[aurelia-view-bundle][href="' + link + '"]').length === 0) {
-    $('body').append('<link aurelia-view-bundle rel="import" href="' + link + '">');
-  }
-
-  fs.writeFileSync(destFile, $.html());
+function inject(outfile, baseURL, injectOptions) {
+  let bundleName = getCanonicalName(outfile);
+  // get config.js
+  // parse it
+  // create and array of bundled moduleNames, 
+  // Create a section for System.config({}) for template bundles
 }
 
 function getCanonicalName(builder, file, pluginName) {


### PR DESCRIPTION
Until now, our view bundle injection is just adding a `<link aurelia-view-bundle href="bundle-file-path" /> ` in `index` file. This works but we can do better. We want something like SystemJS bundle injection. When SystemJS tries to load a module, it searches  `bundle: []` section in `config.js`  and if the module is found there, SystemJS loads the entire bundle. This way multiple bundle may be injected in `config.js` and loader will load as needed. A large app with multiple  `sections` really benefits from this as we can create bundle per section. This helps `initial loading` faster because as we are not loading everything upfront.

This PR is aiming to achieve the same pattern for  `Aurelia Views`