### PR TITLE
enhancement: Connect History API Fallback

### DIFF
--- a/lib/resources/tasks/run.js
+++ b/lib/resources/tasks/run.js
@@ -3,6 +3,7 @@ import browserSync from 'browser-sync';
 import project from '../aurelia.json';
 import build from './build';
 import {CLIOptions} from 'aurelia-cli';
+import historyApiFallback from 'connect-history-api-fallback/lib';
 
 function onChange(path) {
   console.log(`File Changed: ${path}`);
@@ -22,10 +23,10 @@ let serve = gulp.series(
       port: 9000,
       server: {
         baseDir: ['.'],
-        middleware: function(req, res, next) {
+        middleware: [historyApiFallback(), function(req, res, next) {
           res.setHeader('Access-Control-Allow-Origin', '*');
           next();
-        }
+        }]
       }
     }, done);
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "aurelia-dependency-injection": "^1.0.0-beta.1.2.0",
     "aurelia-polyfills": "^1.0.0-beta.1.1.2",
+    "connect-history-api-fallback": "^1.2.0",
     "npm": "^3.8.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "aurelia-dependency-injection": "^1.0.0-beta.1.2.0",
     "aurelia-polyfills": "^1.0.0-beta.1.1.2",
-    "connect-history-api-fallback": "^1.2.0",
     "npm": "^3.8.6"
   }
 }


### PR DESCRIPTION
- Added `historyApiFallback()` function to middleware for `serve` task.

Adding the [connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback) allows paths added via PushState to be accessed directly when browsing by typing the path into the querystring, e.g. `/contact` and also when BrowserSync reloads the application due to changes.

This makes it a lot more convenient than having to navigate back to the page you were on when your app reloads.