### PR TITLE
fix(undefined-property): Use options over config

### DIFF
--- a/lib/resources/tasks/transpile.js
+++ b/lib/resources/tasks/transpile.js
@@ -22,7 +22,7 @@ function buildJavaScript() {
     .pipe(plumber({errorHandler: notify.onError('Error: <%= error.message %>')}))
     .pipe(changedInPlace({firstPass:true}))
     .pipe(sourcemaps.init())
-    .pipe(babel(project.transpiler.config))
+    .pipe(babel(project.transpiler.options))
     .pipe(build.bundle());
 }
 


### PR DESCRIPTION
The `project.transpiler.config` was undefined. Changing this to `project.transpiler.options` allowed me to use the babel plugins