### PR TITLE
fix(transpile.ts): fix typescript watch transpile

### DIFF
--- a/lib/resources/tasks/transpile.ts
+++ b/lib/resources/tasks/transpile.ts
@@ -7,6 +7,7 @@ import * as rename from 'gulp-rename';
 import * as ts from 'gulp-typescript';
 import * as project from '../aurelia.json';
 import {CLIOptions, build} from 'aurelia-cli';
+import * as eventStream from 'event-stream';
 
 function configureEnvironment() {
   let env = CLIOptions.getEnvironment();
@@ -26,9 +27,13 @@ function buildTypeScript() {
     });
   }
 
-  return gulp.src(project.transpiler.dtsSource.concat(project.transpiler.source))
-    .pipe(plumber({errorHandler: notify.onError('Error: <%= error.message %>')}))
-    .pipe(changedInPlace({firstPass:true}))
+  let dts = gulp.src(project.transpiler.dtsSource);
+
+  let src = gulp.src(project.transpiler.source)
+    .pipe(changedInPlace({firstPass: true}));
+
+  return eventStream.merge(dts, src)
+    .pipe(plumber({ errorHandler: notify.onError('Error: <%= error.message %>') }))
     .pipe(sourcemaps.init())
     .pipe(ts(typescriptCompiler))
     .pipe(build.bundle());


### PR DESCRIPTION
merge the `.d.ts` files with the changed `.ts` files so referenced types transpile properly

NOTE: this introduces a dev dependency on npm package `event-stream`