### PR TITLE
fix(config) : make sure that moduleId is set in config

### DIFF
--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -110,6 +110,9 @@ exports.BundledSource = class {
           if (item.requiresTransform) {
             item.contents = result.contents;
             item.requiresTransform = false;
+            if (!item.moduleId) {
+              item.moduleId = result.id;
+            }
           }
         } else if (this.includedBy.traceDependencies) {
           bundler.addFile({


### PR DESCRIPTION
If a library in an extra bundle (not vendor-bundle) is referenced in the app code, the bundle config/metadata injected in vendor-bundle is missing the moduleIds (being emitted as null). (Which causes the module files not being loaded correctly at run time). This change fixes that.