### PR TITLE
feat(bundle): add an option to use absolute path in requirejs

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -196,6 +196,12 @@ exports.Bundle = class {
     let config = Object.assign({}, loaderConfig);
     let location = platform.baseUrl || platform.output;
 
+    if (platform.useAbsolutePath) {
+      location = '/' + location;
+    } else {
+      location = '../' + location;
+    }
+
     for (let i = 0; i < bundles.length; ++i) {
       let currentBundle = bundles[i];
       let currentName = currentBundle.config.name;
@@ -208,7 +214,7 @@ exports.Bundle = class {
         bundleMetadata[currentBundle.moduleId] = currentBundle.getBundledModuleIds();
       }
 
-      config.paths[currentBundle.moduleId] = '../' + location + '/' + currentBundle.moduleId;
+      config.paths[currentBundle.moduleId] = location + '/' + currentBundle.moduleId;
     }
 
     if (includeBundles) {


### PR DESCRIPTION
For instance, on a page with this URL /a/b, by default the bundles will be loaded with this URL /a/scripts/bundle.js. If platform.useAbsolutePath is set to true, they will be loaded with /scripts/bundle.js instead.