### PR TITLE
chore(linting): fix eslint warnings in resources

### DIFF
--- a/lib/resources/generators/attribute.js
+++ b/lib/resources/generators/attribute.js
@@ -26,7 +26,7 @@ export default class AttributeGenerator {
   }
 
   generateSource(className) {
-return `import {inject} from 'aurelia-framework';
+    return `import {inject} from 'aurelia-framework';
 
 @inject(Element)
 export class ${className}CustomAttribute {
@@ -39,6 +39,6 @@ export class ${className}CustomAttribute {
   }
 }
 
-`
+`;
   }
 }

--- a/lib/resources/generators/binding-behavior.js
+++ b/lib/resources/generators/binding-behavior.js
@@ -26,7 +26,7 @@ export default class BindingBehaviorGenerator {
   }
 
   generateSource(className) {
-return `export class ${className}BindingBehavior {
+    return `export class ${className}BindingBehavior {
   bind(binding, source) {
 
   }

--- a/lib/resources/generators/element.js
+++ b/lib/resources/generators/element.js
@@ -27,7 +27,7 @@ export default class ElementGenerator {
   }
 
   generateJSSource(className) {
-return `import {bindable} from 'aurelia-framework';
+    return `import {bindable} from 'aurelia-framework';
 
 export class ${className} {
   @bindable value;
@@ -37,12 +37,12 @@ export class ${className} {
   }
 }
 
-`
+`;
   }
 
   generateHTMLSource(className) {
-return `<template>
+    return `<template>
   <h1>\${value}</h1>
-</template>`
+</template>`;
   }
 }

--- a/lib/resources/generators/generator.js
+++ b/lib/resources/generators/generator.js
@@ -26,7 +26,7 @@ export default class GeneratorGenerator {
   }
 
   generateSource(className) {
-return `import {inject} from 'aurelia-dependency-injection';
+    return `import {inject} from 'aurelia-dependency-injection';
 import {Project, ProjectItem, CLIOptions, UI} from 'aurelia-cli';
 
 @inject(Project, CLIOptions, UI)
@@ -68,6 +68,6 @@ export class \${className} {
   }
 }
 
-`
+`;
   }
 }

--- a/lib/resources/generators/task.js
+++ b/lib/resources/generators/task.js
@@ -26,7 +26,7 @@ export default class TaskGenerator {
   }
 
   generateSource(functionName) {
-return `import gulp from 'gulp';
+    return `import gulp from 'gulp';
 import changed from 'gulp-changed';
 import project from '../aurelia.json';
 
@@ -36,6 +36,6 @@ export default function ${functionName}() {
     .pipe(gulp.dest(project.paths.output));
 }
 
-`
+`;
   }
 }

--- a/lib/resources/generators/value-converter.js
+++ b/lib/resources/generators/value-converter.js
@@ -26,7 +26,7 @@ export default class ValueConverterGenerator {
   }
 
   generateSource(className) {
-return `export class ${className}ValueConverter {
+    return `export class ${className}ValueConverter {
   toView(value) {
 
   }
@@ -36,6 +36,6 @@ return `export class ${className}ValueConverter {
   }
 }
 
-`
+`;
   }
 }

--- a/lib/resources/tasks/process-css.js
+++ b/lib/resources/tasks/process-css.js
@@ -5,6 +5,6 @@ import {build} from 'aurelia-cli';
 
 export default function processCSS() {
   return gulp.src(project.cssProcessor.source)
-    .pipe(changedInPlace({firstPass:true}))
+    .pipe(changedInPlace({firstPass: true}))
     .pipe(build.bundle());
-};
+}

--- a/lib/resources/tasks/process-less.js
+++ b/lib/resources/tasks/process-less.js
@@ -7,8 +7,8 @@ import {build} from 'aurelia-cli';
 
 export default function processCSS() {
   return gulp.src(project.cssProcessor.source)
-    .pipe(changedInPlace({firstPass:true}))
+    .pipe(changedInPlace({firstPass: true}))
     .pipe(sourcemaps.init())
     .pipe(less())
     .pipe(build.bundle());
-};
+}

--- a/lib/resources/tasks/process-markup.js
+++ b/lib/resources/tasks/process-markup.js
@@ -5,6 +5,6 @@ import {build} from 'aurelia-cli';
 
 export default function processMarkup() {
   return gulp.src(project.markupProcessor.source)
-    .pipe(changedInPlace({firstPass:true}))
+    .pipe(changedInPlace({firstPass: true}))
     .pipe(build.bundle());
 }

--- a/lib/resources/tasks/process-postcss.js
+++ b/lib/resources/tasks/process-postcss.js
@@ -12,8 +12,8 @@ export default function processCSS() {
   ];
 
   return gulp.src(project.cssProcessor.source)
-    .pipe(changedInPlace({firstPass:true}))
+    .pipe(changedInPlace({firstPass: true}))
     .pipe(sourcemaps.init())
     .pipe(postcss(processors))
     .pipe(build.bundle());
-};
+}

--- a/lib/resources/tasks/process-pug.js
+++ b/lib/resources/tasks/process-pug.js
@@ -7,7 +7,7 @@ import {build} from 'aurelia-cli';
 
 export default function processMarkup() {
   return gulp.src(project.markupProcessor.source)
-    .pipe(changedInPlace({firstPass:true}))
+    .pipe(changedInPlace({firstPass: true}))
     .pipe(sourcemaps.init())
     .pipe(jade())
     .pipe(build.bundle());

--- a/lib/resources/tasks/process-sass.js
+++ b/lib/resources/tasks/process-sass.js
@@ -9,4 +9,4 @@ export default function processCSS() {
     .pipe(sourcemaps.init())
     .pipe(sass().on('error', sass.logError))
     .pipe(build.bundle());
-};
+}

--- a/lib/resources/tasks/process-stylus.js
+++ b/lib/resources/tasks/process-stylus.js
@@ -7,8 +7,8 @@ import {build} from 'aurelia-cli';
 
 export default function processCSS() {
   return gulp.src(project.cssProcessor.source)
-    .pipe(changedInPlace({firstPass:true}))
+    .pipe(changedInPlace({firstPass: true}))
     .pipe(sourcemaps.init())
     .pipe(stylus())
     .pipe(build.bundle());
-};
+}

--- a/lib/resources/tasks/run.js
+++ b/lib/resources/tasks/run.js
@@ -1,12 +1,16 @@
 import gulp from 'gulp';
-import browserSync from 'browser-sync'
-import historyApiFallback from 'connect-history-api-fallback/lib';;
+import browserSync from 'browser-sync';
+import historyApiFallback from 'connect-history-api-fallback/lib';
 import project from '../aurelia.json';
 import build from './build';
 import {CLIOptions} from 'aurelia-cli';
 
+function log(message) {
+  console.log(message); //eslint-disable-line no-console
+}
+
 function onChange(path) {
-  console.log(`File Changed: ${path}`);
+  log(`File Changed: ${path}`);
 }
 
 function reload(done) {
@@ -29,10 +33,10 @@ let serve = gulp.series(
           next();
         }]
       }
-    }, function (err, bs) {
+    }, function(err, bs) {
       let urls = bs.options.get('urls').toJS();
-      console.log(`Application Available At: ${urls.local}`);
-      console.log(`BrowserSync Available At: ${urls.ui}`);
+      log(`Application Available At: ${urls.local}`);
+      log(`BrowserSync Available At: ${urls.ui}`);
       done();
     });
   }
@@ -46,8 +50,8 @@ let refresh = gulp.series(
 let watch = function() {
   gulp.watch(project.transpiler.source, refresh).on('change', onChange);
   gulp.watch(project.markupProcessor.source, refresh).on('change', onChange);
-  gulp.watch(project.cssProcessor.source, refresh).on('change', onChange)
-}
+  gulp.watch(project.cssProcessor.source, refresh).on('change', onChange);
+};
 
 let run;
 

--- a/lib/resources/tasks/test.js
+++ b/lib/resources/tasks/test.js
@@ -1,4 +1,3 @@
-import gulp from 'gulp';
 import {Server as Karma} from 'karma';
 import {CLIOptions} from 'aurelia-cli';
 

--- a/lib/resources/tasks/transpile.js
+++ b/lib/resources/tasks/transpile.js
@@ -12,7 +12,7 @@ function configureEnvironment() {
   let env = CLIOptions.getEnvironment();
 
   return gulp.src(`aurelia_project/environments/${env}.js`)
-    .pipe(changedInPlace({firstPass:true}))
+    .pipe(changedInPlace({firstPass: true}))
     .pipe(rename('environment.js'))
     .pipe(gulp.dest(project.paths.root));
 }
@@ -20,7 +20,7 @@ function configureEnvironment() {
 function buildJavaScript() {
   return gulp.src(project.transpiler.source)
     .pipe(plumber({errorHandler: notify.onError('Error: <%= error.message %>')}))
-    .pipe(changedInPlace({firstPass:true}))
+    .pipe(changedInPlace({firstPass: true}))
     .pipe(sourcemaps.init())
     .pipe(babel(project.transpiler.options))
     .pipe(build.bundle());


### PR DESCRIPTION
After creating a new project with the Aurelia Cli, I was looking through the code it generated to see what it does. One thing I noticed that `eslint`, with the rules provided by the Cli itself, was giving some errors and warnings on the generated code.

This PR fixes those errors and warnings.

The codebase contains more `eslint` errors and warnings, but I've intentionally scoped this PR to just the resources for now as that's the only code output to client projects as far as I can tell.

CLA was confirmed by Rob on https://github.com/aurelia/bundler/pull/47#issuecomment-164531862.