### PR TITLE
chore(linting): add default aurelia eslint ruleset

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./node_modules/aurelia-tools/.eslintrc.json"
+}

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "aurelia-dependency-injection": "^1.0.0",
     "aurelia-polyfills": "^1.0.0",
     "npm": "^3.10.5"
+  },
+  "devDependencies": {
+    "aurelia-tools": "^0.2.2"
   }
 }


### PR DESCRIPTION
This PR adds the default Aurelia `eslint` ruleset to the project. This helps issues like #266 from regressing.

CLA was confirmed by Rob on https://github.com/aurelia/bundler/pull/47#issuecomment-164531862.