### PR TITLE
fix(build): create ouput directory when missing

### DIFF
--- a/lib/file-system.js
+++ b/lib/file-system.js
@@ -1,5 +1,7 @@
 "use strict";
 const fs = require('fs');
+const nodePath = require('path');
+const mkdirp = require('./mkdirp').mkdirp;
 
 exports.exists = function(path) {
   return new Promise((resolve, reject) => fs.exists(path, resolve));
@@ -13,6 +15,15 @@ exports.mkdir = function(path) {
     });
   });
 };
+
+exports.mkdirp = function(path) {
+  return new Promise((resolve, reject) => {
+    mkdirp(path, error => {
+      if(error) reject(error);
+      else resolve();
+    });
+  });
+}
 
 exports.readdir = function(path) {
   return new Promise((resolve, reject) => {
@@ -40,9 +51,14 @@ exports.readFileSync = function(path, encoding) {
 
 exports.writeFile = function(path, content, encoding) {
   return new Promise((resolve, reject) => {
-    fs.writeFile(path, content, encoding || 'utf8', error => {
-      if (error) reject(error);
-      else resolve();
+    mkdirp(nodePath.dirname(path), err => {
+      if (err) reject(err);
+      else {
+        fs.writeFile(path, content, encoding || 'utf8', error => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }
     });
   });
 }

--- a/lib/mkdirp.js
+++ b/lib/mkdirp.js
@@ -1,0 +1,75 @@
+/* Copyright 2010 James Halliday (mail@substack.net)
+
+This project is free software released under the MIT/X11 license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+"use strict";
+const path = require('path');
+const fs = require('fs');
+const _0777 = parseInt('0777', 8);
+
+function mkdirp (p, opts, f, made) {
+  if (typeof opts === 'function') {
+    f = opts;
+    opts = {};
+  }
+  else if (!opts || typeof opts !== 'object') {
+    opts = { mode: opts };
+  }
+  
+  var mode = opts.mode;
+  var xfs = opts.fs || fs;
+  
+  if (mode === undefined) {
+    mode = _0777 & (~process.umask());
+  }
+  if (!made) made = null;
+  
+  var cb = f || function () {};
+  p = path.resolve(p);
+  
+  xfs.mkdir(p, mode, function (er) {
+    if (!er) {
+      made = made || p;
+      return cb(null, made);
+    }
+    switch (er.code) {
+      case 'ENOENT':
+        mkdirp(path.dirname(p), opts, function (er, made) {
+          if (er) cb(er, made);
+          else mkdirp(p, opts, cb, made);
+        });
+        break;
+
+      // In the case of any other error, just see if there's a dir
+      // there already.  If so, then hooray!  If not, then something
+      // is borked.
+      default:
+        xfs.stat(p, function (er2, stat) {
+          // if the stat fails, then that's super weird.
+          // let the original error be the failure reason.
+          if (er2 || !stat.isDirectory()) cb(er, made)
+          else cb(null, made);
+        });
+        break;
+    }
+  });
+}
+
+exports.mkdirp = mkdirp;


### PR DESCRIPTION
Fixes #241.

It uses a small wrapper around `fs.writeFile` to recursively create the directory it wants to write to when it doesn't exist.

The `filendir` module (and its dependency `mkdirp`) are small, so if you don't want to take an external dependency on them, we could inline them.

CLA was confirmed by Rob on https://github.com/aurelia/bundler/pull/47#issuecomment-164531862.