### PR TITLE
feat(cli): add exit error code

### DIFF
--- a/bin/aurelia-cli.js
+++ b/bin/aurelia-cli.js
@@ -25,5 +25,8 @@ resolve('aurelia-cli', {
   let commandName = userArgs[0];
   let commandArgs = userArgs.slice(1);
 
-  cli.run(commandName, commandArgs).catch(error => console.log(error));
+  cli.run(commandName, commandArgs).catch((error) => {
+      console.log(error);
+      process.exit(1);
+  });
 });


### PR DESCRIPTION
Finishes #242.

The next logical step from here would be to refactor `lib/cli.js` to reject non-success cases:
- help command should exit with error code
- when `establishProject` fails, that should exit with error code as well
- probably more, I'm not very familiar with the project

### Testing

```
$ npm run build:prod

> au build --env prod
[....]
npm ERR! Darwin 15.4.0
npm ERR! argv "/Volumes/Custom/Users/kb/.config/fin/bin/node" "/Volumes/Custom/Users/kb/.config/fin/bin/npm" "run" "build:prod"
npm ERR! node v6.3.1
npm ERR! npm  v3.10.3
npm ERR! code ELIFECYCLE
npm ERR! project-ui@1.0.0 build:prod: `au build --env prod`
npm ERR! Exit status 1
npm ERR! There is likely additional logging output above.

$ echo $?
1
```