### PR TITLE
feat(bundler): allow the user to add custom configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,23 @@ Sometimes you can't get a library to work with the module loading system. That's
 }
 ```
 
+#### Configuring the loader
+
+You can configure the loader by adding a `config` key to `build.loader` with the options you want to add. For instance, if you want to increase the timeout for requirejs, you would do this:
+
+```
+"build": {
+    "loader": {
+        "type": "require",
+        "configTarget": "vendor-bundle.js",
+        "includeBundleMetadataInConfig": "auto",
+        "config": {
+            "waitSeconds": 60
+        }
+    }
+}
+```
+
 ## Styling your Application
 
 There are many ways to style components in Aurelia. The CLI sets up your project to only process styles inside your application's `src` folder. Those styles can then be imported into a view using Aurelia's `require` element.

--- a/lib/build/bundler.js
+++ b/lib/build/bundler.js
@@ -30,6 +30,7 @@ exports.Bundler = class {
       stubModules: [],
       shim: {}
     };
+    Object.assign(this.loaderConfig, this.project.build.loader.config);
 
     this.loaderOptions.plugins = (this.loaderOptions.plugins || []).map(x => {
       let plugin = new LoaderPlugin(this, x);


### PR DESCRIPTION
This allows the user to add an object under `build.loader.config` to
pass additional parameters to the loader. For instance if you need to
increase the timeout for requirejs, you can add this object under
`build.loader.config`:

```
{
  "waitSeconds": 60
}
```