### PR TITLE
fix(source-inclusion): BundledSource must be registered in the bundler

### DIFF
--- a/lib/build/bundler.js
+++ b/lib/build/bundler.js
@@ -102,6 +102,8 @@ exports.Bundler = class {
     } else {
       subsume(this.bundles, found);
     }
+
+    return found;
   }
 
   updateFile(file, inclusion) {

--- a/lib/build/source-inclusion.js
+++ b/lib/build/source-inclusion.js
@@ -46,12 +46,15 @@ exports.SourceInclusion = class {
     let pattern = path.resolve(bundler.project.paths.root, this.pattern);
 
     var subsume = (file, cb) => {
-      let moduleId = path.join(loaderConfig.name, file.path.replace(root, ''));
+      let filePath = file.path;
+      let moduleId = path.join(loaderConfig.name, filePath.replace(root, ''));
       moduleId = moduleId.replace(/\\/g, '/');
       let ext = path.extname(moduleId);
-      let item = new BundledSource(bundler, file);
-      item.moduleId = moduleId.substring(0, moduleId.length - ext.length);
-      this.addItem(item);
+      moduleId = moduleId.substring(0, moduleId.length - ext.length);
+
+      let bundledSource = bundler.addFile(file, this);
+      bundledSource.moduleId = moduleId;
+
       cb(null, file);
     };
 


### PR DESCRIPTION
closes https://github.com/aurelia/cli/issues/270

BundledSource's were created for resources in the bundle config, but the BundledSource's were not registered in the bundler ([this](https://github.com/aurelia/cli/blob/master/lib/build/bundler.js#L96) did not happen). So when the tracer begins to trace all the files (including the resources) it would find [here](https://github.com/aurelia/cli/blob/master/lib/build/bundled-source.js#L82) that the file is not in the bundle and it would create another BundledSource.

Then after logging the files array [here](https://github.com/aurelia/cli/blob/master/lib/build/bundle.js#L115) I noticed that there were two files with the same path: `C:\Development\scaffolded\cli-issue-270\node_modules\my-plugin-with-resources\counter.js`. One of those had a `define` and the other one didn't, and both were persisted to the bundle. 

