### PR TITLE
fix(package-analyzing): allow deeper levels for source root

### DIFF
--- a/lib/build/package-analyzer.js
+++ b/lib/build/package-analyzer.js
@@ -33,29 +33,31 @@ exports.PackageAnalyzer = class {
 }
 
 function loadPackageMetadata(project, description) {
-  setLocation(project, description);
-
-  return fs.readFile(description.metadataLocation).then(data => {
-    description.metadata = JSON.parse(data.toString());
-  });
+  return setLocation(project, description)
+    .then(() => fs.readFile(description.metadataLocation))
+    .then(data => {
+      description.metadata = JSON.parse(data.toString());
+    });
 }
 
 function determineLoaderConfig(project, description) {
   let metadata = description.metadata;
-  let location = description.location;
+  let location = path.resolve(description.location);
   let sourcePath;
 
   if (metadata.jspm) {
     let jspm = metadata.jspm;
 
     if (jspm.directories && jspm.directories.dist) {
-      sourcePath = '../' + path.join(location, jspm.directories.dist, jspm.main);
+      sourcePath = path.join(location, jspm.directories.dist, jspm.main);
     } else {
-      sourcePath = '../' + path.join(location, metadata.main);
+      sourcePath = path.join(location, metadata.main);
     }
   } else {
-    sourcePath = '../' + path.join(location, metadata.main);
+    sourcePath = path.join(location, metadata.main);
   }
+
+  sourcePath = path.relative(path.resolve(project.paths.root), sourcePath);
 
   description.loaderConfig = {
     name: description.name,
@@ -66,36 +68,40 @@ function determineLoaderConfig(project, description) {
 function setLocation(project, description) {
   switch (description.source) {
     case 'npm':
-      description.location = getPackageFolder(description);
-      description.metadataLocation = path.join(description.location, 'package.json');
-      break;
+      return getPackageFolder(project, description)
+        .then(packageFolder => {
+          description.location = packageFolder;
+          description.metadataLocation = path.join(description.location, 'package.json');
+        });
     default:
       throw new Error(`The package source "${description.source}" is not supported.`);
   }
 }
 
-function getPackageFolder(description) {
-  if (!description.loaderConfig || !description.loaderConfig.path) {
-    return path.join('node_modules', description.name);
-  }
+function getPackageFolder(project, description) {
+  return lookupPackageFolderDefaultStrategy(project.paths.root)
+    .catch(error => { throw new Error(`A valid package source could not be found.`) })
+    .then(packageFolder => path.join(packageFolder, description.name));
+}
 
-  let pathParts = description.loaderConfig.path.replace(/\\/g, '/').split('/');
-  let packageFolder = '';
-  let stopOnNext = false;
+// Looks for a node_modules folder from the root path of aurelia
+// With the default lookup strategy of node
+function lookupPackageFolderDefaultStrategy(root, orig) {
+  orig = orig || root;
 
-  for(let i = 0; i < pathParts.length; ++i) {
-    let part = pathParts[i];
+  // Test for root directory
+  if(/^\/$|^[A-Z]:\/*$/g.test(root)) return Promise.reject();
+  return fs.readdir(root)
+    .then(files => {
+      var matches = files.filter(file => file == 'node_modules');
 
-    packageFolder = path.join(packageFolder, part)
-
-    if (stopOnNext) {
-      break;
-    } else if (part === 'node_modules') {
-      stopOnNext = true;
-    }
-  }
-
-  return path.relative('..', packageFolder);
+      // Just choose first entry. There shouldnt be more of them in one folder
+      if(matches.length) {
+        var cwdToRoot = path.resolve(process.cwd(), root);
+        return path.join(cwdToRoot, matches[0]);
+      }
+      else return lookupPackageFolderDefaultStrategy(path.resolve(root, '..'), orig);
+    });
 }
 
 function removeExtension(filePath) {

--- a/lib/build/package-analyzer.js
+++ b/lib/build/package-analyzer.js
@@ -86,9 +86,7 @@ function getPackageFolder(project, description) {
 
 // Looks for a node_modules folder from the root path of aurelia
 // With the default lookup strategy of node
-function lookupPackageFolderDefaultStrategy(root, orig) {
-  orig = orig || root;
-
+function lookupPackageFolderDefaultStrategy(root) {
   // Test for root directory
   if(/^\/$|^[A-Z]:\/*$/g.test(root)) return Promise.reject();
   return fs.readdir(root)
@@ -100,7 +98,7 @@ function lookupPackageFolderDefaultStrategy(root, orig) {
         var cwdToRoot = path.resolve(process.cwd(), root);
         return path.join(cwdToRoot, matches[0]);
       }
-      else return lookupPackageFolderDefaultStrategy(path.resolve(root, '..'), orig);
+      else return lookupPackageFolderDefaultStrategy(path.resolve(root, '..'));
     });
 }
 


### PR DESCRIPTION
Before, the package-analyzer looked for the node_modules folder in only exactly one path step back
to the source files.
I changed this behaviour to use a node-like lookup which looks for the node_modules folder in
the following manner:
./node_modules, ../node_modules, ../../node_modules, etc.

And this allows to put the root of the source (project.paths.root) somewhere deeper in a file-structure.
See Issue #278