### PR TITLE
feat(bundle,source-inclusion): allow `exclude` option in bundle source

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,42 @@ If you selected a project setup that includes unit tests, you can run your tests
 
 Executing `au generate resource` runs a generator to scaffold out typical Aurelia constructs. Resource options are: element, attribute, value-converter, binding-behavior, task and generator. That's right...there's a generator generator so you can write your own. Ex. `au generate element`
 
+## Bundling Your Project
+
+By default, the Aurelia CLI creates two bundles, an `app-bundle.js`, and a `vendor-bundle.js`. An example of the default `app-bundle.js` looks like this:  
+```javascript
+{
+  "name": "app-bundle.js",
+  "source": [
+    "[**/*.js]",
+    "**/*.{css,html}"
+  ]
+}
+```  
+In this setup, we've named the bundle `app-bundle.js`, and have defined what's included by setting the `source` property to be an array of patterns that match to file paths (the patterns are using glob patterns, [minimatch](https://github.com/isaacs/minimatch) to be specific, to find files that match).  
+Optionally, you can define an `exclude` list by setting the `source` property to be an object containing both an `include` and `exclude` array of patterns. This is helpful when you're trying to define multiple bundles from your source code.  
+```javascript
+{
+  "name": "app-bundle.js",
+  "source": {
+    "include": [
+      "[**/*.js]",
+      "**/*.{css,html}"
+    ],
+    "exclude": [
+      "**/sub-module/**/*",
+    ]
+  }
+},
+{
+  "name": "sub-module-bundle.js",
+  "source": [
+    "**/sub-module/**/*",
+  ]
+}
+```
+
+
 ## Adding Client Libraries to Your Project
 
 If you need to add a 3rd party client library to your project, first `npm install` the library. After that, open the `aurelia_project/aurelia.json` file and scroll down to the `build.bundles` section. You'll need to add the library into one of your bundle's `dependencies` sections.

--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -14,7 +14,14 @@ exports.Bundle = class {
     this.dependencies = [];
     this.prepend = (config.prepend || []).filter(x => bundler.itemIncludedInBuild(x));
     this.moduleId = config.name.replace(path.extname(config.name), '');
-    this.includes = (config.source || []).map(x => new SourceInclusion(this, x));
+    this.includes = (config.source || []);
+    this.excludes = [];
+    if(this.includes instanceof Array){
+      this.includes = this.includes.map(x => new SourceInclusion(this, x));
+    } else {
+      this.excludes = (this.includes.exclude || []).map(x => this.createMatcher(x));
+      this.includes = this.includes.include.map(x => new SourceInclusion(this, x));
+    }
     this.buildOptions = bundler.interpretBuildOptions(config.options, bundler.buildOptions);
     this.requiresBuild = true;
     this.fileCache = {};

--- a/lib/build/source-inclusion.js
+++ b/lib/build/source-inclusion.js
@@ -18,6 +18,7 @@ exports.SourceInclusion = class {
 
     this.pattern = pattern;
     this.matcher = this.bundle.createMatcher(pattern);
+	  this.excludes = this.bundle.excludes;
     this.items = [];
   }
 
@@ -27,8 +28,15 @@ exports.SourceInclusion = class {
     this.items.push(item);
   }
 
+  isExcluded(item){
+	  let found = this.excludes.findIndex(exclusion => {			
+			return exclusion.match(item.path);
+		});
+	  return found > -1;
+  }
+  
   trySubsume(item) {
-    if (this.matcher.match(item.path)) {
+    if (this.matcher.match(item.path) && !this.isExcluded(item)) {		
       item.includedBy = this;
       item.includedIn = this.bundle;
       this.items.push(item);


### PR DESCRIPTION
Fixes: https://github.com/aurelia/cli/issues/238
Address some of the issues mentioned here: https://github.com/aurelia/cli/issues/203  
Allow the `source` option in the bundle config to optionally be an
object with two properties, `include`, and `exclude`. This makes it
easier for patterns to be defined by the user, and allows for a more
consistent approach to creating bundles (similar to the aurelia-bundler)