### PR TITLE
fix(resources): use paths.root in aurelia-karma.js

### DIFF
--- a/lib/resources/content/karma.conf.js
+++ b/lib/resources/content/karma.conf.js
@@ -29,6 +29,12 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
-    singleRun: false
+    singleRun: false,
+    // client.args must be a array of string.
+    // Leave 'aurelia-root', project.paths.root in this order so we can find
+    // the root of the aurelia project.
+    client: {
+      args: ['aurelia-root', project.paths.root]
+    }
   });
 };

--- a/lib/resources/content/karma.conf.ts
+++ b/lib/resources/content/karma.conf.ts
@@ -33,6 +33,12 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
-    singleRun: false
+    singleRun: false,
+    // client.args must be a array of string.
+    // Leave 'aurelia-root', project.paths.root in this order so we can find
+    // the root of the aurelia project.
+    client: {
+      args: ['aurelia-root', project.paths.root]
+    }
   });
 };

--- a/lib/resources/test/aurelia-karma.js
+++ b/lib/resources/test/aurelia-karma.js
@@ -2,6 +2,12 @@
   var karma = global.__karma__;
   var requirejs = global.requirejs
   var locationPathname = global.location.pathname;
+  var root = 'src';
+  karma.config.args.forEach(function(value, index) {
+    if (value === 'aurelia-root') {
+      root = karma.config.args[index + 1];
+    }
+  });
 
   if (!karma || !requirejs) {
     return;
@@ -49,7 +55,7 @@
     let originalDefine = global.define;
     global.define = function(name, deps, m) {
       if (typeof name === 'string') {
-        originalDefine('/base/src/' + name, [name], function (result) { return result; });
+        originalDefine('/base/' + root + '/' + name, [name], function (result) { return result; });
       }
 
       return originalDefine(name, deps, m);


### PR DESCRIPTION
To do that, we rely on client.args from karma's configuration to
exchange the values between karma and Aurelia. We can then get the
values in aurelia-karma.js with karma.args.

Close #246