### PR TITLE
Add a "None of the above" choice for the Editor step in the `new` wizard

### DIFF
--- a/lib/commands/new/editors/none.js
+++ b/lib/commands/new/editors/none.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = function() {};

--- a/lib/commands/new/new-application.json
+++ b/lib/commands/new/new-application.json
@@ -276,6 +276,14 @@
             "id": "webstorm",
             "displayName": "WebStorm"
           }
+        },
+        {
+          "displayName": "None of the above",
+          "description": "Do not configure any editor specific options.",
+          "value": {
+            "id": "none",
+            "displayName": "n/a"
+          }
         }
       ]
     },


### PR DESCRIPTION
Adds a new entry to the Editor step in the `new` wizard, called "None of the above".

In the final summary, the option is displayed as "Editor: n/a".
