### PR TITLE
feat(bundler, bundle): abstract out loader config generator

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -144,7 +144,7 @@ exports.Bundle = class {
 
       if (loaderOptions.configTarget === this.config.name) {
         //Add to the config bundle the loader config and change the "index.html" to reference the appropriate config bundle
-        concat.add(undefined, this.writeLoaderConfig(platform, loaderOptions));
+        concat.add(undefined, this.writeLoaderCode(platform));
         contents = concat.content;
         let outputDir = platform.baseUrl || platform.output; //If we have a baseUrl, then the files are served from there, else it's the output
         if (platform.index) {
@@ -205,67 +205,13 @@ exports.Bundle = class {
     });
   }
 
-  writeLoaderConfig(platform, loaderOptions) {
-    let loaderConfig = '';
+  writeLoaderCode(platform) {
+    const createLoaderCode = require('./loader').createLoaderCode;
+    let config = createLoaderCode(platform, this.bundler);
 
-    switch(loaderOptions.type) {
-      case 'require':
-        loaderConfig = this.createRequireJSConfig(platform);
-        break;
-      case 'system':
-        loaderConfig = this.createSystemJSConfig(platform);
-        break;
-      default:
-        throw new Error(`Loader configuration style ${loaderOptions.type} is not supported.`);
-    }
-
-    return 'function _aureliaConfigureModuleLoader(){' + loaderConfig + '}'
+    return 'function _aureliaConfigureModuleLoader(){' + config + '}'
   }
-
-  createRequireJSConfig(platform) {
-    let bundler = this.bundler;
-    let loaderOptions = bundler.loaderOptions;
-    let buildOptions = this.buildOptions;
-    let loaderConfig = bundler.loaderConfig;
-    let bundles = bundler.bundles;
-    let name = this.config.name;
-    let bundleMetadata = {};
-    let includeBundles = shouldIncludeBundleMetadata(bundles, loaderOptions);
-    let config = Object.assign({}, loaderConfig);
-    let location = platform.baseUrl || platform.output;
-
-    if (platform.useAbsolutePath) {
-      location = '/' + location;
-    } else {
-      location = '../' + location;
-    }
-
-    for (let i = 0; i < bundles.length; ++i) {
-      let currentBundle = bundles[i];
-      let currentName = currentBundle.config.name;
-
-      if (currentName === name) {
-        continue;
-      }
-
-      if (includeBundles) {
-        bundleMetadata[currentBundle.moduleId] = currentBundle.getBundledModuleIds();
-      }
-      //If build revisions are enabled, append the revision hash to the appropriate module id
-      config.paths[currentBundle.moduleId] = location + '/' + currentBundle.moduleId + (buildOptions.rev && currentBundle.hash ? '-' + currentBundle.hash : '');
-    }
-
-    if (includeBundles) {
-      config.bundles = bundleMetadata;
-    }
-
-    return 'requirejs.config(' + JSON.stringify(config) + ')';
-  }
-
-  createSystemJSConfig(platform) {
-    throw new Error('SystemJS is not yet supported');
-  }
-
+  
   setIndexFileConfigTarget(platform, location){
     //Replace the reference to the vendor bundle in the "index.html" file to use the correct build revision file (or remove the build revision hash);
     const escapeForRegex = require('./utils').escapeForRegex;

--- a/lib/build/bundler.js
+++ b/lib/build/bundler.js
@@ -151,7 +151,7 @@ exports.Bundler = class {
     });
   }
 
-  write() {
+  build() {
     let index = -1;
     let items = this.bundles;
 
@@ -170,8 +170,11 @@ exports.Bundler = class {
         //Order the bundles so that the bundle containing the config is processed last.
         let configTargetBundleIndex = this.bundles.findIndex(x => x.config.name == this.loaderOptions.configTarget);
         this.bundles.splice(this.bundles.length, 0, this.bundles.splice(configTargetBundleIndex, 1)[0]);
-        return Promise.all(this.bundles.map(x => x.write(this.project.build.targets[0])));
       });
+  }
+  
+  write() {
+    return Promise.all(this.bundles.map(x => x.write(this.project.build.targets[0])));
   }
 }
 

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -18,6 +18,27 @@ exports.src = function(p) {
   return Bundler.create(project, new PackageAnalyzer(project)).then(b => bundler = b);
 }
 
+exports.createLoaderCode = function(p){
+  const createLoaderCode = require('./loader').createLoaderCode;
+  project = p || project;
+  return buildLoaderConfig(project)
+      .then(() => {
+        let platform = project.build.targets[0];
+        return createLoaderCode(platform, bundler); 
+      });  
+}
+
+exports.createLoaderConfig = function(p){
+  const createLoaderConfig = require('./loader').createLoaderConfig;
+  project = p || project;
+
+  return buildLoaderConfig(project)
+      .then(() => {
+        let platform = project.build.targets[0];
+        return createLoaderConfig(platform, bundler); 
+      });  
+};
+
 exports.bundle = function() {
   return through.obj(function(file, encoding, callback) {
     callback(null, capture(file));
@@ -25,7 +46,25 @@ exports.bundle = function() {
 };
 
 exports.dest = function() {
-  return bundler.write();
+  return bundler.build()
+    .then(() => bundler.write());
+}
+
+function buildLoaderConfig(p){
+  project = p || project;
+  through = require('through2'); //dep of vinyl-fs
+  let configPromise = Promise.resolve();
+
+  if (!bundler) {
+    //If a bundler doesn't exist then chances are we have not run through getting all the files, and therefore the "bundles" will not be complete
+    configPromise = configPromise.then(() => {
+      return Bundler.create(project, new PackageAnalyzer(project)).then(b => bundler = b)
+    });     
+  }  
+
+  return configPromise.then(() => {
+    return bundler.build();   
+  });
 }
 
 function capture(file) {

--- a/lib/build/loader.js
+++ b/lib/build/loader.js
@@ -1,0 +1,101 @@
+"use strict"
+
+const path = require('path');
+const LoaderPlugin = require('./loader-plugin').LoaderPlugin;
+
+exports.createLoaderCode = function createLoaderCode(platform, bundler) {
+    let loaderCode;
+    let loaderOptions = bundler.loaderOptions;
+
+    switch (loaderOptions.type) {
+        case 'require':
+            loaderCode = 'requirejs.config(' + JSON.stringify(exports.createRequireJSConfig(platform, bundler)) + ')';
+            break;
+        case 'system':
+            loaderCode = exports.createSystemJSConfig(platform);
+            break;
+        default:
+            //TODO: Enhancement: Look at a designated folder for any custom configurations
+            throw new Error(`Loader configuration style ${loaderOptions.type} is not supported.`);
+    }
+
+    return loaderCode;
+}
+
+exports.createLoaderConfig = function createLoaderConfig(platform, bundler) {
+    let loaderConfig;
+    let loaderOptions = bundler.loaderOptions;
+
+    switch (loaderOptions.type) {
+        case 'require':
+            loaderConfig = exports.createRequireJSConfig(platform, bundler);
+            break;
+        case 'system':
+            loaderConfig = exports.createSystemJSConfig(platform);
+            break;
+        default:
+            //TODO: Enhancement: Look at a designated folder for any custom configurations
+            throw new Error(`Loader configuration style ${loaderOptions.type} is not supported.`);
+    }
+
+    return loaderConfig;
+}
+
+exports.createRequireJSConfig = function createRequireJSConfig(platform, bundler) {
+    let loaderOptions = bundler.loaderOptions;
+    let loaderConfig = bundler.loaderConfig;
+    let bundles = bundler.bundles;
+    let configName = loaderOptions.configTarget;
+    let bundleMetadata = {};
+    let includeBundles = shouldIncludeBundleMetadata(bundles, loaderOptions);
+    let config = Object.assign({}, loaderConfig);
+    let location = platform.baseUrl || platform.output;
+
+    if (platform.useAbsolutePath) {
+        location = '/' + location;
+    } else {
+        location = '../' + location;
+    }
+
+    for (let i = 0; i < bundles.length; ++i) {
+        let currentBundle = bundles[i];
+        let currentName = currentBundle.config.name;
+        let buildOptions = bundler.interpretBuildOptions(currentBundle.config.options, bundler.buildOptions); 
+        if (currentName === configName) { //skip over the vendor bundle
+            continue;
+        }
+
+        if (includeBundles) {
+            bundleMetadata[currentBundle.moduleId] = currentBundle.getBundledModuleIds();
+        }
+        //If build revisions are enabled, append the revision hash to the appropriate module id
+        config.paths[currentBundle.moduleId] = location + '/' + currentBundle.moduleId + (buildOptions.rev && currentBundle.hash ? '-' + currentBundle.hash : '');
+    }
+
+    if (includeBundles) {
+        config.bundles = bundleMetadata;
+    }
+
+    return config;
+}
+
+exports.createSystemJSConfig = function createSystemJSConfig(platform) {
+    throw new Error('SystemJS is not yet supported');
+}
+
+function shouldIncludeBundleMetadata(bundles, loaderOptions) {
+    let setting = loaderOptions.includeBundleMetadataInConfig;
+
+    if (typeof setting === 'string') {
+        switch (setting.toLowerCase()) {
+            case 'auto':
+                return bundles.length > 1;
+            case 'true':
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    return setting === true;
+}


### PR DESCRIPTION
Resolves:
https://github.com/aurelia/cli/issues/328
Abstracted out the loader config generator from the `bundle.js`.
Exported on the `build` object the function `generateLoaderConfig`
which can be used to create a loader config without writing your
project to files.
BREAKING INTERNAL CHANGE: `bundler.write` now only writes each bundle,
while `bundler.build` will build each bundle and then write them.