### PR TITLE
Fixes #304, Fixes #322

### DIFF
--- a/lib/resources/tasks/run.ts
+++ b/lib/resources/tasks/run.ts
@@ -23,7 +23,7 @@ let serve = gulp.series(
       port: 9000,
       logLevel: 'silent',
       server: {
-        baseDir: ['.'],
+        baseDir: ['./wwwroot'],
         middleware: [historyApiFallback(), function(req, res, next) {
           res.setHeader('Access-Control-Allow-Origin', '*');
           next();


### PR DESCRIPTION
@EisenbergEffect requested a PR in 322
This changes the `basedDir` property from `['.']` to `['./wwwroot']` as discussed in #304 and #322
