### PR TITLE
fix(dependency-inclusion): wait until all resources are traced before bundling

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -46,7 +46,9 @@ exports.Bundle = class {
 
   addDependency(description) {
     this.dependencies.push(description);
-    this.includes.push(new DependencyInclusion(this, description));
+    let inclusion = new DependencyInclusion(this, description);
+    this.includes.push(inclusion);
+    return inclusion.traceResources();
   }
 
   trySubsume(item) {

--- a/lib/build/dependency-inclusion.js
+++ b/lib/build/dependency-inclusion.js
@@ -10,18 +10,27 @@ exports.DependencyInclusion = class {
     this.items = [];
     this.traceDependencies = true;
     bundle.bundler.addFile(new DependencyFile(bundle, description), this);
+  }
 
-    let loaderConfig = description.loaderConfig;
+  traceResources() {
+    let loaderConfig = this.description.loaderConfig;
     let resources = loaderConfig.resources;
+    let bundle = this.bundle;
 
     if (resources) {
+      let promises = [];
+
       resources.forEach(x => {
         let pattern = path.join(loaderConfig.path, x);
         let inclusion = new SourceInclusion(bundle, pattern);
-        inclusion.addAllMatchingResources(loaderConfig);
+        promises.push(inclusion.addAllMatchingResources(loaderConfig));
         bundle.includes.push(inclusion);
       });
+
+      return Promise.all(promises);
     }
+
+    return Promise.resolve();
   }
 
   addItem(item) {

--- a/lib/build/source-inclusion.js
+++ b/lib/build/source-inclusion.js
@@ -47,26 +47,32 @@ exports.SourceInclusion = class {
   }
 
   addAllMatchingResources(loaderConfig) {
-    const vfs = require('vinyl-fs');
+    return new Promise(resolve => {
+      const vfs = require('vinyl-fs');
 
-    let bundler = this.bundle.bundler;
-    let root = path.resolve(bundler.project.paths.root, loaderConfig.path);
-    let pattern = path.resolve(bundler.project.paths.root, this.pattern);
+      let bundler = this.bundle.bundler;
+      let root = path.resolve(bundler.project.paths.root, loaderConfig.path);
+      let pattern = path.resolve(bundler.project.paths.root, this.pattern);
 
-    var subsume = (file, cb) => {
-      let filePath = file.path;
-      let moduleId = path.join(loaderConfig.name, filePath.replace(root, ''));
-      moduleId = moduleId.replace(/\\/g, '/');
-      let ext = path.extname(moduleId);
-      moduleId = moduleId.substring(0, moduleId.length - ext.length);
+      var subsume = (file, cb) => {
+        let filePath = file.path;
+        let moduleId = path.join(loaderConfig.name, filePath.replace(root, ''));
+        moduleId = moduleId.replace(/\\/g, '/');
+        let ext = path.extname(moduleId);
+        moduleId = moduleId.substring(0, moduleId.length - ext.length);
 
-      let bundledSource = bundler.addFile(file, this);
-      bundledSource.moduleId = moduleId;
+        let bundledSource = bundler.addFile(file, this);
+        bundledSource.moduleId = moduleId;
 
-      cb(null, file);
-    };
+        cb(null, file);
+      };
 
-    vfs.src(pattern).pipe(mapStream(subsume));
+      vfs.src(pattern).pipe(mapStream(subsume))
+        .on('error', e => {
+          console.log(`Error while adding all matching resources of pattern "${this.pattern}": ${e.message}`);
+        })
+        .on('end', resolve);
+    });
   }
 
   transform() {


### PR DESCRIPTION
fixes https://github.com/aurelia/cli/issues/368

After these changes, all 20 box view/view-models are added to the bundle:
![image](https://cloud.githubusercontent.com/assets/2189477/19214822/29459dc8-8d8d-11e6-9252-2c77a0123488.png)

I believe there is another bug somewhere that prevents materialize from working with the cli, but i'll need to look into that. Will open an issue if I find something
