### PR TITLE
feat(autocomplete): disable built-in Angular1 auto-complete/ suggest

### DIFF
--- a/lib/resources/content/settings.json
+++ b/lib/resources/content/settings.json
@@ -1,4 +1,5 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "html.suggest.angular1": false
 }


### PR DESCRIPTION
Most of the users creating a new Aurelia project would probably not need the default built-in Angular1 auto-complete functionality in the newly created project. 

This will turn it off folder/ project based, instead of for all your code (When adding it to user settings). Which allows you to still open up old Angular1 projects and get auto-complete/ suggestions.