### PR TITLE
Fix #382 by catching errors with gulp-plumber

### DIFF
--- a/lib/resources/tasks/process-less.js
+++ b/lib/resources/tasks/process-less.js
@@ -2,12 +2,15 @@ import gulp from 'gulp';
 import changedInPlace from 'gulp-changed-in-place';
 import sourcemaps from 'gulp-sourcemaps';
 import less from 'gulp-less';
+import plumber from 'gulp-plumber';
+import notify from 'gulp-notify';
 import project from '../aurelia.json';
 import {build} from 'aurelia-cli';
 
 export default function processCSS() {
   return gulp.src(project.cssProcessor.source)
     .pipe(changedInPlace({firstPass: true}))
+    .pipe(plumber({ errorHandler: notify.onError('Error: <%= error.message %>') }))
     .pipe(sourcemaps.init())
     .pipe(less())
     .pipe(build.bundle());

--- a/lib/resources/tasks/process-less.ts
+++ b/lib/resources/tasks/process-less.ts
@@ -14,4 +14,4 @@ export default function processCSS() {
     .pipe(sourcemaps.init())
     .pipe(less())
     .pipe(build.bundle());
-};
+}

--- a/lib/resources/tasks/process-less.ts
+++ b/lib/resources/tasks/process-less.ts
@@ -2,12 +2,15 @@ import * as gulp from 'gulp';
 import * as changedInPlace from 'gulp-changed-in-place';
 import * as sourcemaps from 'gulp-sourcemaps';
 import * as less from 'gulp-less';
+import * as plumber from 'gulp-plumber';
+import * as notify from 'gulp-notify';
 import * as project from '../aurelia.json';
 import {build} from 'aurelia-cli';
 
 export default function processCSS() {
   return gulp.src(project.cssProcessor.source)
     .pipe(changedInPlace({firstPass:true}))
+    .pipe(plumber({ errorHandler: notify.onError('Error: <%= error.message %>') }))
     .pipe(sourcemaps.init())
     .pipe(less())
     .pipe(build.bundle());


### PR DESCRIPTION
Stop breaking the stream when a less file doesn't compile by introducing plumber here as well. Also add better error logging through notify. Fixes #382 
