### PR TITLE
refactor (project-template, dependencies): remove unused deps

### DIFF
--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -140,7 +140,6 @@ exports.ProjectTemplate = class {
       ProjectItem.resource('prod.ext', 'environments/prod.js', this.model.transpiler)
     ).addToClientDependencies(
       'aurelia-bootstrapper',
-      'aurelia-fetch-client',
       'aurelia-animator-css',
       'bluebird'
     ).addToDevDependencies(

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -4,7 +4,6 @@ let versionMap = {
   "aurelia-animator-css": "^1.0.0",
   "aurelia-bootstrapper": "^1.0.0",
   "aurelia-cli": "^0.21.0",
-  "aurelia-fetch-client": "^1.0.0",
   "aurelia-testing": "^1.0.0-beta.2.0.0",
   "aurelia-tools": "^0.2.2",
   "autoprefixer": "^6.3.6",


### PR DESCRIPTION
remove unused `aurelia-fetch-client` dependencies that were included by
default.

Resolves: https://github.com/aurelia/cli/issues/389
