### PR TITLE
refactor(project-template,dependencies): move scripts to node modules

### DIFF
--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -77,10 +77,6 @@ exports.ProjectTemplate = class {
       this.projectFolder,
       this.src,
       ProjectItem.directory('wwwroot').add(
-        this.scripts.add(
-          ProjectItem.resource('require.js', 'scripts/require.js'),
-          ProjectItem.resource('text.js', 'scripts/text.js')
-        ),
         ProjectItem.resource('index.html', 'content/index.html').askUserIfExists(),
         ProjectItem.resource('favicon.ico', 'img/favicon.ico').skipIfExists()
       ),
@@ -96,10 +92,6 @@ exports.ProjectTemplate = class {
     this.addToContent(
       this.projectFolder,
       this.src,
-      this.scripts.add(
-        ProjectItem.resource('require.js', 'scripts/require.js'),
-        ProjectItem.resource('text.js', 'scripts/text.js')
-      ),
       ProjectItem.jsonObject('package.json', this.package),
       ProjectItem.resource('.editorconfig', 'content/editorconfig'),
       ProjectItem.resource('.gitignore', 'content/gitignore'),
@@ -142,7 +134,9 @@ exports.ProjectTemplate = class {
       'aurelia-bootstrapper',
       'aurelia-fetch-client',
       'aurelia-animator-css',
-      'bluebird'
+      'bluebird',
+      'requirejs',
+      'text'
     ).addToDevDependencies(
       'aurelia-cli',
       'aurelia-testing',
@@ -302,7 +296,7 @@ exports.ProjectTemplate = class {
           "name":"vendor-bundle.js",
           "prepend": [
             "node_modules/bluebird/js/browser/bluebird.core.js",
-            `${scriptsLocation}/require.js`
+            "node_modules/requirejs/require.js"
           ],
           "dependencies": [
             "aurelia-binding",
@@ -326,10 +320,7 @@ exports.ProjectTemplate = class {
             "aurelia-task-queue",
             "aurelia-templating",
             "aurelia-templating-binding",
-            {
-              "name": "text",
-              "path": `../${scriptsLocation}/text`
-            },
+            "text",
             {
               "name": "aurelia-templating-resources",
               "path": "../node_modules/aurelia-templating-resources/dist/amd",

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -44,6 +44,8 @@ let versionMap = {
   "karma-babel-preprocessor": "^6.0.1",
   "karma-typescript-preprocessor": "^0.2.1",
   "minimatch": "^3.0.2",
+  "requirejs": "^2.3.2",
+  "text": "github:requirejs/text#latest",
   "through2": "^2.0.1",
   "tslint": "^3.11.0",
   "typings": "^1.3.0",


### PR DESCRIPTION
Resolves: https://github.com/aurelia/cli/issues/371
Move RequireJS and the Text plugin into the node_modules so that
generated code is separated from library code.
