### PR TITLE
fix(file-paths): don't use windows style path separators

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -150,14 +150,14 @@ exports.Bundle = class {
         contents = concat.content;
         let outputDir = platform.baseUrl || platform.output; //If we have a baseUrl, then the files are served from there, else it's the output
         if (platform.index) {
-          this.setIndexFileConfigTarget(platform, path.join(outputDir, bundleFileName));
+          this.setIndexFileConfigTarget(platform, path.posix.join(outputDir, bundleFileName));
         }
       }
 
       let mapFileName = bundleFileName + '.map';
-      let mapSourceRoot = path.relative(
-        path.join(process.cwd(), platform.output),
-        path.join(process.cwd(), this.bundler.project.paths.root)
+      let mapSourceRoot = path.posix.relative(
+        path.posix.join(process.cwd(), platform.output),
+        path.posix.join(process.cwd(), this.bundler.project.paths.root)
       );
 
       console.log(`Writing ${bundleFileName}...`);
@@ -184,11 +184,11 @@ exports.Bundle = class {
         contents += os.EOL + '//# sourceMappingURL=' + mapFileName;
       }
 
-      return fs.writeFile(path.join(platform.output, bundleFileName), contents).then(() => {
+      return fs.writeFile(path.posix.join(platform.output, bundleFileName), contents).then(() => {
         this.requiresBuild = false;
 
         if (mapContents) {
-          return fs.writeFile(path.join(platform.output, mapFileName), mapContents);
+          return fs.writeFile(path.posix.join(platform.output, mapFileName), mapContents);
         }
       });
     });

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -60,5 +60,5 @@ function modifyFilename(pth, modifier){
 	}
 
 	var ext = path.extname(pth);
-	return path.join(path.dirname(pth), modifier(path.basename(pth, ext), ext));
+	return path.posix.join(path.dirname(pth), modifier(path.basename(pth, ext), ext));
 }

--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -257,9 +257,9 @@ exports.ProjectTemplate = class {
 
     let scriptsLocation = this.scripts.calculateRelativePath(this.projectFolder.parent)
 
-    this.model.transpiler.source = path.join(appRoot, '**/*' + this.model.transpiler.fileExtension);
-    this.model.markupProcessor.source = path.join(appRoot, '**/*' + this.model.markupProcessor.fileExtension);
-    this.model.cssProcessor.source = path.join(appRoot, '**/*' + this.model.cssProcessor.fileExtension);
+    this.model.transpiler.source = path.posix.join(appRoot, '**/*' + this.model.transpiler.fileExtension);
+    this.model.markupProcessor.source = path.posix.join(appRoot, '**/*' + this.model.markupProcessor.fileExtension);
+    this.model.cssProcessor.source = path.posix.join(appRoot, '**/*' + this.model.cssProcessor.fileExtension);
     this.model.platform.output = scriptsLocation;
     this.model.platform.index = "index.html";
 
@@ -268,7 +268,7 @@ exports.ProjectTemplate = class {
     }
 
     if (this.unitTests.parent) {
-      this.model.unitTestRunner.source = path.join(
+      this.model.unitTestRunner.source = path.posix.join(
         this.unitTests.calculateRelativePath(this.projectFolder.parent),
         '**/*' + this.model.transpiler.fileExtension
       );
@@ -357,7 +357,7 @@ exports.ProjectTemplate = class {
   install(ui) {
     let workingDirectory = this.options.hasFlag('here')
       ? process.cwd()
-      : path.join(process.cwd(), this.content.calculateRelativePath());
+      : path.posix.join(process.cwd(), this.content.calculateRelativePath());
 
     return installDependencies(ui, workingDirectory)
       .then(() => runPostInstallProcesses(ui, workingDirectory, this.postInstallProcesses));

--- a/lib/project-item.js
+++ b/lib/project-item.js
@@ -65,7 +65,7 @@ exports.ProjectItem = class {
       ? this.parent.calculateRelativePath(fromLocation)
       : '';
 
-    return path.join(parentRelativePath, this.name);
+    return path.posix.join(parentRelativePath, this.name);
   }
 
   setJSONObject(jsonObject) {
@@ -89,7 +89,7 @@ exports.ProjectItem = class {
   }
 
   create(ui, relativeTo) {
-    let fullPath = relativeTo ? path.join(relativeTo, this.name) : this.name;
+    let fullPath = relativeTo ? path.posix.join(relativeTo, this.name) : this.name;
 
     if (this.isDirectory) {
       return fs.exists(fullPath).then(result => {


### PR DESCRIPTION
Resolves: https://github.com/aurelia/cli/issues/332
Use universal (posix) path separators when creating user side code.
