### PR TITLE
fix(sourcemaps): stop adding non-existent sourcemaps to sourcemap

### DIFF
--- a/lib/build/concat-with-sourcemaps/index.js
+++ b/lib/build/concat-with-sourcemaps/index.js
@@ -45,7 +45,7 @@ Concat.prototype.add = function(filePath, content, sourceMap) {
   }
   this.contentParts.push(content);
 
-  if (this.sourceMapping) {
+  if (sourceMap && this.sourceMapping) {
     var contentString = content.toString();
     var lines = contentString.split('\n').length;
 


### PR DESCRIPTION
Fixes #409 

Only add sourcemaps to the sourcemap list if a sourcemap exists for the file.

Interestingly, this also makes the source mapped `src` folder show up the "correct" place.

![image](https://cloud.githubusercontent.com/assets/9885322/20284191/1f752858-aa8a-11e6-8999-c228ca38cc63.png)


Verified that sourcemaps now work in Edge:
![image](https://cloud.githubusercontent.com/assets/9885322/20284268/6d83199c-aa8a-11e6-9305-8f9b3d800f8a.png)


