### PR TITLE
fix(transform): enable wrap shim for shimmed definitions

### DIFF
--- a/lib/build/amodro-trace/lib/loader/Loader.js
+++ b/lib/build/amodro-trace/lib/loader/Loader.js
@@ -223,7 +223,7 @@ function __exec(contents, r, d, c) {
     // build output.
     context.makeShimExports = function (value) {
       var fn;
-      if (context.config._options.wrapShim) {
+      if (context.config.wrapShim) {
         fn = function () {
           var str = 'return ';
           // If specifies an export that is just a global

--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -95,7 +95,8 @@ exports.BundledSource = class {
           return cjsTransform(url, contents);
         },
         writeTransform: allWriteTransforms({
-          stubModules: loaderConfig.stubModules
+          stubModules: loaderConfig.stubModules,
+          writeShim: loaderConfig.writeShim
         })
       },
       loaderConfig


### PR DESCRIPTION
This allows aurelia.json specify in the loader config that it wants to wrap a shimmed library in a define. Allows this section of code to be useful https://github.com/aurelia/cli/blob/master/lib/build/amodro-trace/write/defines.js#L41-L55