### PR TITLE
fix(project-template): use wwwroot as build target for aspnet core

### DIFF
--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -34,8 +34,6 @@ exports.ProjectTemplate = class {
       ? ProjectItem.directory(process.cwd())
       : ProjectItem.directory(model.name);
 
-    this.scripts = ProjectItem.directory('scripts');
-
     this.resources = ProjectItem.directory('resources');
     this.elements = ProjectItem.directory('elements');
     this.attributes = ProjectItem.directory('attributes');
@@ -73,10 +71,12 @@ exports.ProjectTemplate = class {
   configureVisualStudioStructure() {
     this.content = this.root;
 
+    this.projectOutput = ProjectItem.directory('wwwroot');
+
     this.addToContent(
       this.projectFolder,
       this.src,
-      ProjectItem.directory('wwwroot').add(
+      this.projectOutput.add(
         ProjectItem.resource('index.html', 'content/index.html').askUserIfExists(),
         ProjectItem.resource('favicon.ico', 'img/favicon.ico').skipIfExists()
       ),
@@ -86,8 +86,10 @@ exports.ProjectTemplate = class {
     );
   }
 
+  // If content is always empty (web.js platform invokes this method without parameters) we can remove it. Otherwise shouldn't we add it in the configureVisualStudioStructure too?
   configureDefaultStructure(content) {
     this.content = content || this.root;
+    this.projectOutput = this.root;
 
     this.addToContent(
       this.projectFolder,
@@ -101,6 +103,9 @@ exports.ProjectTemplate = class {
   }
 
   configureDefaultSetup() {
+    this.scripts = ProjectItem.directory('scripts');
+    this.projectOutput.add(this.scripts);
+
     this.addToSource(
       ProjectItem.resource('main.ext', 'src/main.ext', this.model.transpiler),
       ProjectItem.resource('app.ext', 'src/app.ext', this.model.transpiler),
@@ -236,33 +241,31 @@ exports.ProjectTemplate = class {
   }
 
   create(ui, location) {
-    let appRoot = this.src.calculateRelativePath(this.projectFolder.parent);
-    let e2eRoot = this.e2eTests.calculateRelativePath(this.projectFolder.parent);
+    let appRoot = this.src.calculateRelativePath(this.root);
+    let e2eRoot = this.e2eTests.calculateRelativePath(this.root);
 
     this.model.paths = Object.assign(this.model.paths, {
       root: appRoot,
-      resources: this.resources.calculateRelativePath(this.projectFolder.parent),
-      elements: this.elements.calculateRelativePath(this.projectFolder.parent),
-      attributes: this.attributes.calculateRelativePath(this.projectFolder.parent),
-      valueConverters: this.valueConverters.calculateRelativePath(this.projectFolder.parent),
-      bindingBehaviors: this.bindingBehaviors.calculateRelativePath(this.projectFolder.parent)
+      resources: this.resources.calculateRelativePath(this.root),
+      elements: this.elements.calculateRelativePath(this.root),
+      attributes: this.attributes.calculateRelativePath(this.root),
+      valueConverters: this.valueConverters.calculateRelativePath(this.root),
+      bindingBehaviors: this.bindingBehaviors.calculateRelativePath(this.root)
     });
-
-    let scriptsLocation = this.scripts.calculateRelativePath(this.projectFolder.parent)
 
     this.model.transpiler.source = path.posix.join(appRoot, '**/*' + this.model.transpiler.fileExtension);
     this.model.markupProcessor.source = path.posix.join(appRoot, '**/*' + this.model.markupProcessor.fileExtension);
     this.model.cssProcessor.source = path.posix.join(appRoot, '**/*' + this.model.cssProcessor.fileExtension);
-    this.model.platform.output = scriptsLocation;
-    this.model.platform.index = "index.html";
+    this.model.platform.output = this.scripts.calculateRelativePath(this.root);
+    this.model.platform.index = path.posix.join(this.projectOutput.calculateRelativePath(this.root), "index.html");
 
     if (this.model.platform.id === 'aspnetcore') {
-      this.model.platform.baseUrl = this.scripts.calculateRelativePath(this.scripts.parent)
+      this.model.platform.baseUrl = this.scripts.calculateRelativePath(this.projectOutput);
     }
 
     if (this.unitTests.parent) {
       this.model.unitTestRunner.source = path.posix.join(
-        this.unitTests.calculateRelativePath(this.projectFolder.parent),
+        this.unitTests.calculateRelativePath(this.root),
         '**/*' + this.model.transpiler.fileExtension
       );
     }

--- a/lib/project-item.js
+++ b/lib/project-item.js
@@ -61,6 +61,10 @@ exports.ProjectItem = class {
   }
 
   calculateRelativePath(fromLocation) {
+    if(this === fromLocation){
+      return '';
+    }
+
     let parentRelativePath = (this.parent && this.parent !== fromLocation)
       ? this.parent.calculateRelativePath(fromLocation)
       : '';


### PR DESCRIPTION
The "new" command configuration has been changed in order to prepend the folder "wwwroot" to both
the output and index properties used during the bundling of an aspnet core project

Closes issue #405