### PR TITLE
fix #303 Time required to build and/or run a project is seemingly excessive

### DIFF
--- a/lib/build/amodro-trace/index.js
+++ b/lib/build/amodro-trace/index.js
@@ -89,6 +89,7 @@ module.exports = function trace(options, loaderConfig) {
 
     function onOk() {
       var context = loader.getContext();
+      var traceCache = context._traceCache || {};
 
       // Pull out the list of IDs for this layer as the return value.
       var paths = context._layer.buildFilePaths,
@@ -144,10 +145,9 @@ module.exports = function trace(options, loaderConfig) {
         }
 
         if (options.includeContents && filePath) {
-          const cached = options.traced && options.traced.find(item => item.id === id);
-
-          if (cached && cached.contents) {
-            item.contents = cached.contents;
+          var cacheEntry = traceCache[id];
+          if (cacheEntry && cacheEntry.contents) {
+            item.contents = cacheEntry.contents;
           } else {
             var contents = context._readTransformedContents[filePath];
             if (!contents && context.fileExists(id, filePath)) {

--- a/lib/build/amodro-trace/index.js
+++ b/lib/build/amodro-trace/index.js
@@ -146,7 +146,7 @@ module.exports = function trace(options, loaderConfig) {
         if (options.includeContents && filePath) {
           const cached = options.traced && options.traced.find(item => item.id === id);
 
-          if (cached) {
+          if (cached && cached.contents) {
             item.contents = cached.contents;
           } else {
             var contents = context._readTransformedContents[filePath];

--- a/lib/build/amodro-trace/index.js
+++ b/lib/build/amodro-trace/index.js
@@ -144,22 +144,28 @@ module.exports = function trace(options, loaderConfig) {
         }
 
         if (options.includeContents && filePath) {
-          var contents = context._readTransformedContents[filePath];
-          if (!contents && context.fileExists(id, filePath)) {
-            contents = context.fileRead(id, filePath) || '';
-            if (options.writeTransform) {
-              contents = options
-                         .writeTransform(context, id, filePath, contents);
-            }
-          }
-          if (contents && options.writeTransform) {
-            contents = options.writeTransform(context,
-                                              id,
-                                              filePath,
-                                              contents);
-          }
+          const cached = options.traced && options.traced.find(item => item.id === id);
 
-          item.contents = contents;
+          if (cached) {
+            item.contents = cached.contents;
+          } else {
+            var contents = context._readTransformedContents[filePath];
+            if (!contents && context.fileExists(id, filePath)) {
+              contents = context.fileRead(id, filePath) || '';
+              if (options.writeTransform) {
+                contents = options
+                           .writeTransform(context, id, filePath, contents);
+              }
+            }
+            if (contents && options.writeTransform) {
+              contents = options.writeTransform(context,
+                                                id,
+                                                filePath,
+                                                contents);
+            }
+
+            item.contents = contents;
+          }
         }
 
         if (filePath) {

--- a/lib/build/amodro-trace/lib/loader/Loader.js
+++ b/lib/build/amodro-trace/lib/loader/Loader.js
@@ -139,6 +139,9 @@ function __exec(contents, r, d, c) {
     // Stores the _options.readTransform contents for use in top level results.
     context._readTransformedContents = {};
 
+    // Stores previous trace results for use in this trace.
+    context._traceCache = {};
+
     // For tracing, do everything sync so that build runs are more reproducible.
     // Otherwise, async IO could lead to differing results.
     context.nextTick = function (fn) {
@@ -293,7 +296,7 @@ function __exec(contents, r, d, c) {
     context.load = function (moduleName, url) {
       /*jslint evil: true */
       var contents, pluginBuilderMatch, builderName,
-        shim, shimExports,
+        shim, shimExports, traceCacheEntry,
         currentLoadingUrl = context.currentLoadingUrl;
 
       // If this module is no longer in the registry, because it was undefined,
@@ -352,66 +355,77 @@ function __exec(contents, r, d, c) {
             layer.existingRequireUrl = url;
           }
         } else {
-          // Load the file contents, process for conditionals, then
-          // evaluate it.
-          contents = context.fileRead(moduleName, url);
-
-          if (context.config._options.readTransform) {
-            contents = context.config._options
-                       .readTransform(moduleName, url, contents);
-          }
-
-          if (context.config._options.includeContents) {
-            context._readTransformedContents[url] = contents;
-          }
-
-          // Find out if the file contains a require() definition. Need to
-          // know this so we can inject plugins right after it, but before
-          // they are needed, and to make sure this file is first, so that
-          // define calls work.
-          try {
-            if (!layer.existingRequireUrl &&
-                parse.definesRequire(url, contents)) {
-              layer.existingRequireUrl = url;
-              context._cachedDefinesRequireUrls[url] = true;
+          traceCacheEntry = getOwn(context._traceCache, moduleName);
+          if (traceCacheEntry) {
+            contents = 'define("' + moduleName + '",';
+            if (traceCacheEntry.deps) {
+              contents += '["' + traceCacheEntry.deps.join('","') + '"]';
+            } else {
+              contents += '[]';
             }
-          } catch (e1) {
-            throw new Error('Parse error using esprima ' +
-                    'for file: ' + url + '\n' + e1);
-          }
+            contents += ');';
+          } else {
+            // Load the file contents, process for conditionals, then
+            // evaluate it.
+            contents = context.fileRead(moduleName, url);
 
-          if (hasProp(context.plugins, moduleName)) {
-            // This is a loader plugin, check to see if it has a build
-            // extension, otherwise the plugin will act as the plugin
-            // builder too.
-            pluginBuilderMatch = pluginBuilderRegExp.exec(contents);
-            if (pluginBuilderMatch) {
-              // Load the plugin builder for the plugin contents.
-              builderName = context.makeModuleMap(pluginBuilderMatch[3],
-                                context.makeModuleMap(moduleName),
-                                null,
-                                true).id;
-              contents = context.fileRead(builderName,
-                                          context.nameToUrl(builderName));
+            if (context.config._options.readTransform) {
+              contents = context.config._options
+                         .readTransform(moduleName, url, contents);
             }
-          }
 
-          // Parse out the require and define calls.
-          // Do this even for plugins in case they have their own
-          // dependencies that may be separate to how the pluginBuilder
-          // works.
-          try {
-            if (falseProp(context.needFullExec, moduleName)) {
-              contents = parse(moduleName, url, contents, {
-                insertNeedsDefine: true,
-                has: context.config.has,
-                findNestedDependencies:
-                              context.config._options.findNestedDependencies
-              });
+            if (context.config._options.includeContents) {
+              context._readTransformedContents[url] = contents;
             }
-          } catch (e2) {
-            throw new Error('Parse error using esprima ' +
-                    'for file: ' + url + '\n' + e2);
+
+            // Find out if the file contains a require() definition. Need to
+            // know this so we can inject plugins right after it, but before
+            // they are needed, and to make sure this file is first, so that
+            // define calls work.
+            try {
+              if (!layer.existingRequireUrl &&
+                  parse.definesRequire(url, contents)) {
+                layer.existingRequireUrl = url;
+                context._cachedDefinesRequireUrls[url] = true;
+              }
+            } catch (e1) {
+              throw new Error('Parse error using esprima ' +
+                      'for file: ' + url + '\n' + e1);
+            }
+
+            if (hasProp(context.plugins, moduleName)) {
+              // This is a loader plugin, check to see if it has a build
+              // extension, otherwise the plugin will act as the plugin
+              // builder too.
+              pluginBuilderMatch = pluginBuilderRegExp.exec(contents);
+              if (pluginBuilderMatch) {
+                // Load the plugin builder for the plugin contents.
+                builderName = context.makeModuleMap(pluginBuilderMatch[3],
+                                  context.makeModuleMap(moduleName),
+                                  null,
+                                  true).id;
+                contents = context.fileRead(builderName,
+                                            context.nameToUrl(builderName));
+              }
+            }
+
+            // Parse out the require and define calls.
+            // Do this even for plugins in case they have their own
+            // dependencies that may be separate to how the pluginBuilder
+            // works.
+            try {
+              if (falseProp(context.needFullExec, moduleName)) {
+                contents = parse(moduleName, url, contents, {
+                  insertNeedsDefine: true,
+                  has: context.config.has,
+                  findNestedDependencies:
+                                context.config._options.findNestedDependencies
+                });
+              }
+            } catch (e2) {
+              throw new Error('Parse error using esprima ' +
+                      'for file: ' + url + '\n' + e2);
+            }
           }
 
           context._cachedFileContents[url] = contents;
@@ -655,8 +669,14 @@ function __exec(contents, r, d, c) {
       inlineText: true
     });
 
+    var context = this.getContext();
+    context._setToolOptions(options || {});
 
-    this.getContext()._setToolOptions(options || {});
+    if (options.traced) {
+      options.traced.forEach(function(traceItem) {
+        context._traceCache[traceItem.id] = traceItem;
+      });
+    }
   }
 
   Loader.prototype = {

--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -5,6 +5,19 @@ const cjsTransform = require('./amodro-trace/read/cjs');
 const allWriteTransforms = require('./amodro-trace/write/all');
 const fs = require('../file-system');
 
+let _cache = {};
+
+function cacheTraced(traced) {
+  traced.forEach(item => {
+    const {id, deps, contents} = item;
+    _cache[item.id] = {id, deps, contents};
+  });
+}
+
+function cachedTraced() {
+  return Object.values(_cache);
+}
+
 exports.BundledSource = class {
   constructor(bundler, file) {
     this.bundler = bundler;
@@ -70,6 +83,7 @@ exports.BundledSource = class {
       {
         rootDir: rootDir,
         id: moduleId,
+        traced: cachedTraced(),
         fileExists: function(defaultExists, id, filePath) {
           return !!bundler.getItemByPath(calculateFileName(filePath));
         },
@@ -101,6 +115,7 @@ exports.BundledSource = class {
       loaderConfig
     ).then(traceResult => {
       let traced = traceResult.traced;
+      cacheTraced(traced);
 
       for (let i = 0, ii = traced.length; i < ii; ++i) {
         let result = traceResult.traced[i];

--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -9,8 +9,7 @@ let _cache = {};
 
 function cacheTraced(traced) {
   traced.forEach(item => {
-    const {id, deps, contents} = item;
-    _cache[item.id] = {id, deps, contents};
+    _cache[item.id] = {id: item.id, deps: item.deps, contents: item.contents};
   });
 }
 

--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -81,7 +81,9 @@ exports.BundledSource = class {
         id: moduleId,
         traced: bundler.getTraced(),
         fileExists: function(defaultExists, id, filePath) {
-          return !!bundler.getItemByPath(calculateFileName(filePath));
+          // always force amodro to use our fileRead func.
+          // this bypasses amodro bug https://github.com/amodrojs/amodro-trace/issues/6
+          return true;
         },
         fileRead: function(defaultRead, id, filePath) {
           let location = calculateFileName(filePath);

--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -14,7 +14,11 @@ function cacheTraced(traced) {
 }
 
 function cachedTraced() {
-  return Object.values(_cache);
+  let values = [];
+  for(let key in _cache) {
+    values.push(_cache[key]);
+  }
+  return values;
 }
 
 exports.BundledSource = class {

--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -5,22 +5,6 @@ const cjsTransform = require('./amodro-trace/read/cjs');
 const allWriteTransforms = require('./amodro-trace/write/all');
 const fs = require('../file-system');
 
-let _cache = {};
-
-function cacheTraced(traced) {
-  traced.forEach(item => {
-    _cache[item.id] = {id: item.id, deps: item.deps, contents: item.contents};
-  });
-}
-
-function cachedTraced() {
-  let values = [];
-  for(let key in _cache) {
-    values.push(_cache[key]);
-  }
-  return values;
-}
-
 exports.BundledSource = class {
   constructor(bundler, file) {
     this.bundler = bundler;
@@ -29,6 +13,7 @@ exports.BundledSource = class {
     this.includedBy = null;
     this.moduleId = null;
     this._contents = null;
+    this._deps = null;
     this.requiresTransform = true;
   }
 
@@ -38,6 +23,14 @@ exports.BundledSource = class {
 
   get path() {
     return this.file.path;
+  }
+
+  set deps(deps) {
+    this._deps = deps || [];
+  }
+
+  get deps() {
+    return this._deps;
   }
 
   set contents(value) {
@@ -86,7 +79,7 @@ exports.BundledSource = class {
       {
         rootDir: rootDir,
         id: moduleId,
-        traced: cachedTraced(),
+        traced: bundler.getTraced(),
         fileExists: function(defaultExists, id, filePath) {
           return !!bundler.getItemByPath(calculateFileName(filePath));
         },
@@ -118,13 +111,13 @@ exports.BundledSource = class {
       loaderConfig
     ).then(traceResult => {
       let traced = traceResult.traced;
-      cacheTraced(traced);
 
       for (let i = 0, ii = traced.length; i < ii; ++i) {
         let result = traceResult.traced[i];
         let item = bundler.getItemByPath(result.path);
 
         if (item) {
+          item.deps = result.deps;
           if (item.requiresTransform) {
             item.contents = result.contents;
             item.requiresTransform = false;
@@ -133,10 +126,12 @@ exports.BundledSource = class {
             }
           }
         } else if (this.includedBy.traceDependencies) {
-          bundler.addFile({
-            path: result.path,
-            contents: result.contents
-          }, this.includedBy);
+          let newItem = bundler.addFile({
+                          path: result.path,
+                          contents: result.contents
+                        }, this.includedBy);
+
+          newItem.deps = result.deps;
         }
       }
     });

--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -90,7 +90,8 @@ exports.BundledSource = class {
           let found = bundler.getItemByPath(location);
 
           if (found) {
-            return found.contents;
+            // ensure to use contents before stub
+            return found.contentsBeforeStub || found.contents;
           } else {
             let contents = fs.readFileSync(location).toString();
 
@@ -121,6 +122,10 @@ exports.BundledSource = class {
         if (item) {
           item.deps = result.deps;
           if (item.requiresTransform) {
+            if (loaderConfig.stubModules.indexOf(result.id) >= 0) {
+              // retain contents before stub
+              item.contentsBeforeStub = item.contents;
+            }
             item.contents = result.contents;
             item.requiresTransform = false;
             if (!item.moduleId) {

--- a/lib/build/bundler.js
+++ b/lib/build/bundler.js
@@ -88,6 +88,26 @@ exports.Bundler = class {
     return this.itemLookup[normalizeKey(path)];
   }
 
+  // cached traced to feedback to amodro-trace
+  getTraced() {
+    let traced = [];
+
+    for (let key in this.itemLookup) {
+      const item = this.itemLookup[key];
+      if (!item.moduleId || !item.deps) continue;
+
+      let traceItem = {id: item.moduleId, deps: item.deps};
+
+      if (!item.requiresTransform) {
+        traceItem.contents = item.contents;
+      }
+
+      traced.push(traceItem)
+    }
+
+    return traced;
+  }
+
   addFile(file, inclusion) {
     let key =  normalizeKey(file.path);
     let found = this.itemLookup[key];
@@ -172,7 +192,7 @@ exports.Bundler = class {
         this.bundles.splice(this.bundles.length, 0, this.bundles.splice(configTargetBundleIndex, 1)[0]);
       });
   }
-  
+
   write() {
     return Promise.all(this.bundles.map(x => x.write(this.project.build.targets[0])));
   }

--- a/lib/build/bundler.js
+++ b/lib/build/bundler.js
@@ -91,10 +91,13 @@ exports.Bundler = class {
   // cached traced to feedback to amodro-trace
   getTraced() {
     let traced = [];
+    const stubModules = this.loaderConfig.stubModules;
 
     for (let key in this.itemLookup) {
       const item = this.itemLookup[key];
       if (!item.moduleId || !item.deps) continue;
+      // don't put stubbed in cache
+      if (stubModules.indexOf(item.moduleId) >= 0) continue;
 
       let traceItem = {id: item.moduleId, deps: item.deps};
 


### PR DESCRIPTION
This fix patches amodro to use cached deps and contents to avoid duplicated work. It's able to cut of ~70% build time on my project.

Works in watch mode too. (it seems cli doesn't use amodro to process additional file change)
Works in `au build --env prod` too at least on my project.

This should close #303.