### PR TITLE
fix(package-analyzing): allow deeper levels for source root

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -35,9 +35,14 @@ exports.Bundle = class {
     return Promise.all(
       dependencies
         .filter(x => bundler.itemIncludedInBuild(x))
-        .map(dependency => bundler.configureDependency(dependency)
-        .then(description => bundle.addDependency(description)))
-    ).then(() => bundle);
+        .map(dependency => bundler.configureDependency(dependency))
+    )
+    // Add dependencies in the same order as they were entered
+    // to prevent a wrong module load order.
+    .then(descriptions => 
+      descriptions.forEach(description => 
+        bundle.addDependency(description)))
+    .then(() => bundle);
   }
 
   createMatcher(pattern) {

--- a/lib/build/package-analyzer.js
+++ b/lib/build/package-analyzer.js
@@ -33,29 +33,31 @@ exports.PackageAnalyzer = class {
 }
 
 function loadPackageMetadata(project, description) {
-  setLocation(project, description);
-
-  return fs.readFile(description.metadataLocation).then(data => {
-    description.metadata = JSON.parse(data.toString());
-  });
+  return setLocation(project, description)
+    .then(() => fs.readFile(description.metadataLocation))
+    .then(data => {
+      description.metadata = JSON.parse(data.toString());
+    });
 }
 
 function determineLoaderConfig(project, description) {
   let metadata = description.metadata;
-  let location = description.location;
+  let location = path.resolve(description.location);
   let sourcePath;
 
   if (metadata.jspm) {
     let jspm = metadata.jspm;
 
     if (jspm.directories && jspm.directories.dist) {
-      sourcePath = '../' + path.join(location, jspm.directories.dist, jspm.main);
+      sourcePath = path.join(location, jspm.directories.dist, jspm.main);
     } else {
-      sourcePath = '../' + path.join(location, metadata.main);
+      sourcePath = path.join(location, metadata.main);
     }
   } else {
-    sourcePath = '../' + path.join(location, metadata.main);
+    sourcePath = path.join(location, metadata.main);
   }
+
+  sourcePath = path.relative(path.resolve(project.paths.root), sourcePath);
 
   description.loaderConfig = {
     name: description.name,
@@ -66,20 +68,30 @@ function determineLoaderConfig(project, description) {
 function setLocation(project, description) {
   switch (description.source) {
     case 'npm':
-      description.location = getPackageFolder(description);
-      description.metadataLocation = path.join(description.location, 'package.json');
-      break;
+      return getPackageFolder(project, description)
+        .then(packageFolder => {
+          description.location = packageFolder;
+          description.metadataLocation = path.join(description.location, 'package.json');
+        });
     default:
       throw new Error(`The package source "${description.source}" is not supported.`);
   }
 }
 
-function getPackageFolder(description) {
+function getPackageFolder(project, description) {
   if (!description.loaderConfig || !description.loaderConfig.path) {
-    return path.join('node_modules', description.name);
+    return lookupPackageFolderDefaultStrategy(project.paths.root)
+      .catch(error => { throw new Error(`A valid package source could not be found.`) })
+      .then(packageFolder => path.join(packageFolder, description.name));
   }
+  
+  return lookupPackageFolderRelativeStrategy(project.paths.root, description.loaderConfig.path);
+}
 
-  let pathParts = description.loaderConfig.path.replace(/\\/g, '/').split('/');
+// Looks for the node_modules folder from the root path of aurelia
+// with the defined loaderConfig.
+function lookupPackageFolderRelativeStrategy(root, relativePath) {
+  let pathParts = relativePath.replace(/\\/g, '/').split('/');
   let packageFolder = '';
   let stopOnNext = false;
 
@@ -95,7 +107,25 @@ function getPackageFolder(description) {
     }
   }
 
-  return path.relative('..', packageFolder);
+  return Promise.resolve(path.resolve(root, packageFolder));
+}
+
+// Looks for a node_modules folder from the root path of aurelia
+// With the default lookup strategy of node
+function lookupPackageFolderDefaultStrategy(root) {
+  // Test for root directory
+  if(/^\/$|^[A-Z]:\/*$/g.test(root)) return Promise.reject();
+  return fs.readdir(root)
+    .then(files => {
+      var matches = files.filter(file => file == 'node_modules');
+
+      // Just choose first entry. There shouldnt be more of them in one folder
+      if(matches.length) {
+        var cwdToRoot = path.resolve(process.cwd(), root);
+        return path.join(cwdToRoot, matches[0]);
+      }
+      else return lookupPackageFolderDefaultStrategy(path.resolve(root, '..'));
+    });
 }
 
 function removeExtension(filePath) {


### PR DESCRIPTION
@EisenbergEffect as you asked for, here is the new PR for https://github.com/aurelia/cli/pull/363.
This time it should be right :-)

Actual description:
>Before, the package-analyzer looked for the node_modules folder in only exactly one path step back
to the source files.
I changed this behaviour to use a node-like lookup which looks for the node_modules folder in
the following manner:
./node_modules, ../node_modules, ../../node_modules, etc.

>And this allows to put the root of the source (project.paths.root) somewhere deeper in a file-structure.

Remark:
>As a quick remark:
>When putting the sources in a deeper structure, one has to set the "build.targets.useAbsolutePath" to true in the aurelia.json, otherwise requirejs tries to load the scripts from a wrong directory (I couldn't track this down so well, maybe you have some insight?)
Otherwise it works fine with my test setups and additional module load tries. One has to go sure that all paths to the source files in aurelia.json are adjusted. (This could lead to some trouble if one just adjusts the "paths.root" only.

Best, alpox