### PR TITLE
feat(build): add --watch option to build

### DIFF
--- a/lib/resources/tasks/build.js
+++ b/lib/resources/tasks/build.js
@@ -1,11 +1,12 @@
 import gulp from 'gulp';
+import {CLIOptions} from 'aurelia-cli';
 import transpile from './transpile';
 import processMarkup from './process-markup';
 import processCSS from './process-css';
 import {build} from 'aurelia-cli';
 import project from '../aurelia.json';
 
-export default gulp.series(
+let buildTask = gulp.series(
   readProjectConfiguration,
   gulp.parallel(
     transpile,
@@ -15,6 +16,10 @@ export default gulp.series(
   writeBundles
 );
 
+function onChange(path) {
+  console.log(`File Changed: ${path}`);
+}
+
 function readProjectConfiguration() {
   return build.src(project);
 }
@@ -22,3 +27,22 @@ function readProjectConfiguration() {
 function writeBundles() {
   return build.dest();
 }
+
+let watch = function() {
+  gulp.watch(project.transpiler.source, buildTask).on('change', onChange);
+  gulp.watch(project.markupProcessor.source, buildTask).on('change', onChange);
+  gulp.watch(project.cssProcessor.source, buildTask).on('change', onChange)
+}
+
+let task;
+
+if (CLIOptions.hasFlag('watch')) {
+  task = gulp.series(
+    buildTask,
+    watch
+  );
+} else {
+  task = buildTask;
+}
+
+export default task;

--- a/lib/resources/tasks/build.json
+++ b/lib/resources/tasks/build.json
@@ -6,6 +6,11 @@
       "name": "env",
       "description": "Sets the build environment.",
       "type": "string"
+    },
+    {
+      "name": "watch",
+      "description": "Watches source files for changes and rebuilds the app automatically.",
+      "type": "boolean"
     }
   ]
 }

--- a/lib/resources/tasks/build.ts
+++ b/lib/resources/tasks/build.ts
@@ -1,11 +1,12 @@
 import * as gulp from 'gulp';
+import {CLIOptions} from 'aurelia-cli';
 import transpile from './transpile';
 import processMarkup from './process-markup';
 import processCSS from './process-css';
 import {build} from 'aurelia-cli';
 import * as project from '../aurelia.json';
 
-export default gulp.series(
+let buildTask = gulp.series(
   readProjectConfiguration,
   gulp.parallel(
     transpile,
@@ -15,6 +16,10 @@ export default gulp.series(
   writeBundles
 );
 
+function onChange(path) {
+  console.log(`File Changed: ${path}`);
+}
+
 function readProjectConfiguration() {
   return build.src(project);
 }
@@ -22,3 +27,22 @@ function readProjectConfiguration() {
 function writeBundles() {
   return build.dest();
 }
+
+let watch = function() {
+  gulp.watch(project.transpiler.source, buildTask).on('change', onChange);
+  gulp.watch(project.markupProcessor.source, buildTask).on('change', onChange);
+  gulp.watch(project.cssProcessor.source, buildTask).on('change', onChange)
+}
+
+let task;
+
+if (CLIOptions.hasFlag('watch')) {
+  task = gulp.series(
+    buildTask,
+    watch
+  );
+} else {
+  task = buildTask;
+}
+
+export default task;


### PR DESCRIPTION
Add a watch option to build to rebuild the application when files change, without using a Browsersync server.

Fixes #240.