### PR TITLE
feat(typescript): set lib to es2017 for upcoming js features

### DIFF
--- a/lib/resources/content/tsconfig.json
+++ b/lib/resources/content/tsconfig.json
@@ -10,7 +10,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
-    "lib": ["es2015", "dom"]
+    "lib": ["es2017", "dom"]
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
The "es2017" value encompasses ES2015 and ES2016 as well as the upcoming ES2017.