### PR TITLE
fix: user relative path for source maps with empty `mappings` property

### DIFF
--- a/lib/build/concat-with-sourcemaps/index.js
+++ b/lib/build/concat-with-sourcemaps/index.js
@@ -77,9 +77,7 @@ Concat.prototype.add = function(filePath, content, sourceMap) {
         });
       }
     } else {
-      if (sourceMap && sourceMap.sources && sourceMap.sources.length > 0)
-        filePath = sourceMap.sources[0];
-      if (filePath) {
+      if (sourceMap && sourceMap.file) {
         for (var i = 1; i <= lines; i++) {
           this._sourceMap.addMapping({
             generated: {
@@ -90,11 +88,11 @@ Concat.prototype.add = function(filePath, content, sourceMap) {
               line: i,
               column: 0
             },
-            source: filePath
+            source: sourceMap.file
           });
         }
-        if (sourceMap && sourceMap.sourcesContent)
-          this._sourceMap.setSourceContent(filePath, sourceMap.sourcesContent[0]);
+        if (sourceMap.sourcesContent && sourceMap.sourcesContent[0])
+          this._sourceMap.setSourceContent(sourceMap.file, sourceMap.sourcesContent[0]);
       }
     }
     if (lines > 1)


### PR DESCRIPTION
When `sourceMap` object with empty `mappings` property is encountered, bundled source map contains absolute instead of relative path of source file.