### PR TITLE
chore(test):Add missing .js extensions after normalization

### DIFF
--- a/lib/resources/test/aurelia-karma.js
+++ b/lib/resources/test/aurelia-karma.js
@@ -32,6 +32,12 @@
       normalized.push(parts[i])
     }
 
+    // Use case of testing source code. RequireJS doesn't add .js extension to files asked via sibling selector
+    // If normalized path doesn't include some type of extension, add the .js to it
+    if (normalized.length > 0 && normalized[normalized.length - 1].indexOf('.') < 0) {
+      normalized[normalized.length - 1] = normalized[normalized.length - 1] + '.js'
+    }
+
     return normalized.join('/')
   }
 


### PR DESCRIPTION
Shamelessly copied from http://stackoverflow.com/a/40246316 after I bumped into this issue myself.
In my opinion, an new cli project should support this out of the box. This would otherwise get especially confusing with TypeScript as one would need to use a .js extension in the import for a .ts file.