### PR TITLE
Package importer

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,6 +5,8 @@ const fs = require('./file-system');
 const ui = require('./ui');
 const Project = require('./project').Project;
 const CLIOptions = require('./cli-options').CLIOptions;
+const LogManager = require('aurelia-logging');
+const Logger = require('./logger').Logger;
 
 exports.CLI = class {
   constructor(options) {
@@ -27,7 +29,18 @@ exports.CLI = class {
         }
 
         return this.createCommand(command, args);
-      }).then(command => command.execute(args));
+      })
+      .then((command) => {
+        this.configureLogger();
+
+        return command.execute(args);
+      });
+  }
+
+  configureLogger() {
+    LogManager.addAppender(this.container.get(Logger));
+    let level = CLIOptions.hasFlag('debug') ? LogManager.logLevel.debug : LogManager.logLevel.info;
+    LogManager.setLevel(level);
   }
 
   configureContainer() {

--- a/lib/commands/help/command.js
+++ b/lib/commands/help/command.js
@@ -35,6 +35,8 @@ module.exports = class {
   getLocalCommandText() {
     let commands = [
       require('../generate/command.json'),
+      require('../import/command.json'),
+      require('../install/command.json'),
       require('./command.json')
     ];
 

--- a/lib/commands/import/command.js
+++ b/lib/commands/import/command.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const ImportEngine = require('../../importer/import-engine'),
+      ArgumentParser = require('../install/package-argument-parser');
+
+module.exports = class {
+
+  static inject() { return [ImportEngine, ArgumentParser]; };
+
+  constructor(engine, argumentParser) {
+    this.engine = engine;
+    this.argumentParser = argumentParser;
+  }
+
+  execute(args) {
+    let packages = this.argumentParser.parse(args);
+
+    if (packages.length === 0) {
+      throw new Error('Expected atleast one package (au import <package>)');
+    }
+
+    return this.engine
+      .import(packages)
+      .catch(e => { console.log(e); });
+  }
+};

--- a/lib/commands/import/command.json
+++ b/lib/commands/import/command.json
@@ -1,0 +1,10 @@
+{
+  "name": "import",
+  "description": "Configures a package in aurelia.json",
+  "parameters": [
+    {
+      "name": "packages",
+      "description": "Package names, separated by spaces"
+    }
+  ]
+}

--- a/lib/commands/install/command.js
+++ b/lib/commands/install/command.js
@@ -1,7 +1,31 @@
 "use strict";
 
+const ImportCommand = require('../import/command'),
+      PackageInstaller = require('../../importer/package-installer'),
+      ArgumentParser = require('./package-argument-parser'),
+      logger = require('aurelia-logging').getLogger('Install');
+
 module.exports = class {
+
+  static inject() { return [PackageInstaller, ImportCommand, ArgumentParser]; };
+
+  constructor(packageInstaller, importCommand, argumentParser) {
+    this.packageInstaller = packageInstaller;
+    this.importCommand = importCommand;
+    this.argumentParser = argumentParser;
+  }
+
   execute(args) {
-    return new Promise((resolve, reject) => reject(new Error('Install not yet implemented.')))
+    let packages = new ArgumentParser().parse(args);
+
+    if (packages.length === 0) {
+      throw new Error('Expected atleast one package (au import <package>)');
+    }
+
+    return this.packageInstaller
+      .install(packages)
+      .then(() => logger.info('The packages were successfully installed. Going to import them now.'))
+      .then(() => this.importCommand.execute(args))
+      .catch(e => console.log(e));
   }
 }

--- a/lib/commands/install/command.json
+++ b/lib/commands/install/command.json
@@ -1,0 +1,10 @@
+{
+  "name": "install",
+  "description": "Installs and configures a package in aurelia.json",
+  "parameters": [
+    {
+      "name": "packages",
+      "description": "Package names, separated by spaces. Versioning is supported (jquery@3.0.0)"
+    }
+  ]
+}

--- a/lib/commands/install/package-argument-parser.js
+++ b/lib/commands/install/package-argument-parser.js
@@ -1,0 +1,80 @@
+"use strict";
+
+const gitRegex = /(?:git|ssh|https?|git@[\w\.]+):(?:\/\/)?([\w\.@:\/~_-]+)\.git(?:\/?|\#[\d\w\.\-_]+?)$/;
+
+class PackageArgumentParser {
+
+  parse(args) {
+    let packages = [];
+    let flag = false;
+
+    for(let i = 0; i < args.length; i++) {
+      let arg = args[i];
+
+      if (flag) {
+        flag = false;
+        continue;
+      }
+
+      // skip arguments starting with - or --
+      if (arg.startsWith('--')) continue;
+      if (arg.match(/^-.$/)) {
+        flag = true;  
+        continue;
+      }
+
+      let pkg;
+
+      if (this.isGitUrl(arg)) {
+        pkg = this.parseGitUrl(arg);
+      } else if (this.hasVersion(arg)) {
+        pkg = this.parseVersioned(arg);
+      } else {
+        pkg = {
+          argument: arg,
+          name: arg  
+        };
+      }
+      packages.push(pkg);
+    }
+
+    return packages;
+  }
+
+  parseVersioned(argument) {
+    let split = argument.split('@');
+    return {
+      argument: argument,
+      name: split[0],
+      version: split[1]
+    };
+  }
+
+  hasVersion(argument) {
+    return argument.indexOf('@') > -1;
+  }
+
+  isGitUrl(argument) {
+    return argument.match(gitRegex);
+  }
+
+  parseGitUrl(argument) {
+    let matches = argument.match(gitRegex);
+
+    // github.com/aurelia/i18n
+    let segment = matches[1];
+
+    // aurelia/i18n
+    let repo = segment.substring(segment.indexOf('/') + 1);
+
+    // aurelia-i18n
+    let name = repo.replace('/', '-');
+
+    return {
+      argument: argument,
+      name: name
+    };
+  }
+}
+
+module.exports = PackageArgumentParser;

--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -1,6 +1,6 @@
 "use strict";
 const ProjectItem = require('../../project-item').ProjectItem;
-const NPM = require('../../npm').NPM;
+const NPM = require('../../package-managers/npm').NPM;
 const path = require('path');
 const string = require('../../string');
 const getSupportedVersion = require('../../dependencies').getSupportedVersion;

--- a/lib/file-system.js
+++ b/lib/file-system.js
@@ -3,8 +3,14 @@ const fs = require('fs');
 const nodePath = require('path');
 const mkdirp = require('./mkdirp').mkdirp;
 
+exports.fs = fs;
+
 exports.exists = function(path) {
   return new Promise((resolve, reject) => fs.exists(path, resolve));
+};
+
+exports.existsSync = function(path) {
+  return fs.existsSync(path);
 };
 
 exports.mkdir = function(path) {
@@ -48,6 +54,22 @@ exports.readFileSync = fs.readFileSync;
 exports.readFileSync = function(path, encoding) {
   return fs.readFileSync(path, encoding || 'utf8');
 };
+
+exports.copySync = function(sourceFile, targetFile) {
+  fs.writeFileSync(targetFile, fs.readFileSync(sourceFile));
+};
+
+exports.resolve = function(path) {
+  return nodePath.resolve(path);
+};
+
+exports.join = function(...segments) {
+  return nodePath.join.apply(this, segments);
+};
+
+exports.statSync = function (path) {
+  return fs.statSync(path);
+}
 
 exports.writeFile = function(path, content, encoding) {
   return new Promise((resolve, reject) => {

--- a/lib/importer/import-engine.js
+++ b/lib/importer/import-engine.js
@@ -1,0 +1,74 @@
+"use strict";
+
+const fs = require('../file-system'),
+      UI = require('../ui').UI,
+      CLIOptions = require('../cli-options').CLIOptions,
+      Container = require('aurelia-dependency-injection').Container,
+      StrategyLoader = require('./strategy-loader'),
+      Tutorial = require('./services/tutorial'),
+      MetadataService = require('./services/metadata-service'),
+      ResourceInclusion = require('./services/resource-inclusion'),
+      Registry = require('./services/registry'),
+      logger = require('aurelia-logging').getLogger('Importer'),
+      Package = require('./package'),
+      Project = require('../project').Project,
+      PackageImporter = require('./package-importer');
+
+module.exports = class {
+
+  static inject() { return [CLIOptions, Container, Project, UI]; }
+
+  constructor(cliOptions, container, project, ui) {
+    this.cliOptions = cliOptions;
+    this.container = container;
+    this.project = project;
+    this.ui = ui;
+  }
+
+  import(packages) {
+    var index = 0;
+    var that = this;
+
+    function _importPackage () {
+      if (index == packages.length) {
+        return Promise.resolve();
+      }
+
+      return that.importPackage(packages[index++])
+      .then(_importPackage);
+    }
+
+    return _importPackage();
+  }
+
+  importPackage(pkg) {
+    let container = this.getContainer(pkg);
+    let importer = container.get(PackageImporter);
+    return importer.import();
+  }
+
+  getContainer(pkg) {
+    // use a clean DI container for the entire import process
+    let container = new Container();
+
+    pkg = new Package(pkg);
+
+    container.registerInstance('parameters', {
+        action: 'install',
+        bundle: this.cliOptions.getFlagValue('bundle', '-b') || this.project.getDefaultBundle().name
+    });
+    container.registerInstance(UI, this.ui);
+    container.registerInstance('project', this.project);
+    container.registerInstance('package', pkg);
+    container.registerInstance('fs', fs);
+    container.registerAlias(UI, 'ui');
+    container.registerAlias(ResourceInclusion, 'resource-inclusion');
+    container.registerAlias(MetadataService, 'metadata-service');
+    container.registerAlias(Registry, 'registry');
+
+    pkg.resourceInclusion = container.get('resource-inclusion');
+
+    return container;
+  }
+};
+

--- a/lib/importer/package-importer.js
+++ b/lib/importer/package-importer.js
@@ -1,0 +1,87 @@
+"use strict";
+
+const Container = require('aurelia-dependency-injection').Container,
+      StrategyLoader = require('./strategy-loader'),
+      Tutorial = require('./services/tutorial'),
+      MetadataService = require('./services/metadata-service'),
+      logger = require('aurelia-logging').getLogger('Importer');
+
+module.exports = class {
+  static inject() { return [Container, 'package', StrategyLoader, Tutorial, MetadataService]; };
+
+  constructor(container, pkg, strategyLoader, tutorial, metadataService) {
+    this.container = container;
+    this.package = pkg;
+    this.strategies = strategyLoader.getStrategies();
+    this.tutorial = tutorial;
+    this.metadataService = metadataService;
+  }
+
+  import() {
+    if (!this.package.isInstalled()) {
+      logger.info(`Package "${this.package.name}" has not been installed. Skipping.`);
+      return Promise.resolve();
+    }
+
+    logger.info(`---------------------------------------------------------`);
+    logger.info(`*********** Configuring ${this.package.name} ***********`);
+
+    this.package.fetchPackageJSON().parsePackageJSON();
+
+    return this.findStrategy()
+    .then(strategy => {
+      if (!strategy) {
+        throw new Error('No strategies were able to configure this package. Please let us know.');
+      }
+
+      logger.info(`[OK] Going to execute the "${strategy.name}" strategy`);
+
+      return Promise.resolve(strategy.execute())
+      .catch(err => {
+        logger.error(`An error occurred during the exection of the "${strategy.name}" importer strategy`);
+        logger.error(err);
+        logger.error(err.stack);
+
+        throw err;
+      })
+      .then(instructions => {
+        logger.info(`*********** Finished configuring ${this.package.name} ***********`);
+
+        if (instructions) {
+          logger.debug('Applying the following configuration: ', instructions);
+          
+          return this.metadataService.execute(instructions)
+          .then(() => this.tutorial.start(instructions));
+        }
+
+        return this.tutorial.start();
+      })
+    })
+    .then(() => logger.info(`---------------------------------------------------------`));
+  }
+
+  findStrategy() {
+    var index = 0;
+
+    function _findStrategy() {
+      if (index === this.strategies.length) {
+        return;
+      }
+
+      var strategy = this.strategies[index++];
+      
+      return Promise.resolve(strategy.applies())
+      .then(canExecute => {
+        if (!canExecute) {
+          logger.debug(`[SKIP] The "${strategy.name}" strategy declined configuration`);
+
+          return _findStrategy.call(this);
+        }
+
+        return strategy;
+      });
+    }
+
+    return _findStrategy.call(this);
+  }
+};

--- a/lib/importer/package-installer.js
+++ b/lib/importer/package-installer.js
@@ -1,0 +1,45 @@
+"use strict";
+
+const Project = require('../project').Project,
+      logger = require('aurelia-logging').getLogger('Package-installer');
+
+let PackageInstaller = class {
+  static inject() { return [Project] };
+
+  constructor(project) {
+    this.project = project;
+  }
+
+  install(packages) {
+    let aureliaJSON = this.project.model;
+    let packageManager = aureliaJSON.packageManager || 'npm';
+    let options = {};
+    let ctor;
+
+    logger.info(`Using '${packageManager}' to install the package(s). You can change this by setting the 'packageManager' property in the aurelia.json file to 'npm' or 'yarn'.`);
+
+    try {
+      ctor = require(`../package-managers/${packageManager}`).default;
+    } catch (e) {
+      logger.error(`Could not load the ${packageManager} package installer. Falling back to NPM`, e);
+
+      packageManager = 'npm';
+      ctor = require(`../package-managers/${packageManager}`).default;
+    }
+
+    let installer = new ctor();
+
+    if (packageManager === 'npm') {
+      options = { 
+        progress: false,
+        save: true
+      };
+    }
+    
+    logger.info('*********** INSTALLING PACKAGES ***********');
+
+    return installer.install(packages.map(x => x.argument), options);
+  }
+};
+
+module.exports = PackageInstaller;

--- a/lib/importer/package.js
+++ b/lib/importer/package.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const fs = require('../file-system'),
+      path = require('path');
+
+module.exports = class {
+  constructor(pkg) {
+    this.name = pkg.name;
+    this.path = path.posix.join('../node_modules/', this.name);
+    this.rootPath = fs.resolve(fs.join('node_modules', this.name));
+    this.packageJSONPath = fs.join(this.rootPath, 'package.json');
+    this.resources = [];
+  }
+
+  isInstalled(pkg) {
+    return fs.existsSync(this.packageJSONPath);
+  }
+
+  fetchPackageJSON() {
+    this.packageJSON = JSON.parse(fs.readFileSync(this.packageJSONPath, 'utf8'));
+    return this;
+  }
+  
+  getModuleId(fileName) {
+    let moduleId = fileName.replace(/\\/g, '/');
+    let ext = path.extname(moduleId);
+    moduleId = moduleId.substring(0, moduleId.length - ext.length);
+
+    return moduleId;
+  }
+
+  detectResources() {
+    return this.resourceInclusion.getCSS()
+    .then(resources => {
+      for(let resource of resources) {
+        this.resources.push(resource);
+      }
+    });
+  }
+
+  parsePackageJSON() {
+    this.name = this.packageJSON.name;
+    this.version = this.packageJSON.version;
+
+    if (this.packageJSON.main && !this.main) {
+      this.main = this.packageJSON.main;
+    }
+
+    return this;
+  }
+
+  getConfiguration() {
+    let config;
+
+    if (this.main) {
+      config = {
+        name: this.name,
+        main: this.main,
+        path: this.path,
+        resources: this.resources
+      };
+    } else {
+      config = this.name;
+    }
+
+    return config;
+  }
+};

--- a/lib/importer/registry/bootstrap/0.0.0.json
+++ b/lib/importer/registry/bootstrap/0.0.0.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": [{
+    "name": "bootstrap",
+    "path": "../node_modules/bootstrap/dist",
+    "main": "js/bootstrap.min",
+    "deps": ["jquery"],
+    "exports": "$"
+  }]
+}

--- a/lib/importer/registry/jquery/0.0.0.json
+++ b/lib/importer/registry/jquery/0.0.0.json
@@ -1,0 +1,5 @@
+{
+  "tutorial": [
+    "1. Import jQuery via: \"import $ from 'jquery';\""
+  ]
+}

--- a/lib/importer/services/metadata-service.js
+++ b/lib/importer/services/metadata-service.js
@@ -1,0 +1,162 @@
+"use strict";
+
+const copySync = require('../../file-system').copySync,
+      join = require('../../file-system').join,
+      statSync = require('../../file-system').statSync,
+      execSync = require('child_process').execSync,
+      logger = require('aurelia-logging').getLogger('Metadata');
+
+let MetadataService = class {
+
+  static inject() { return ['package', 'parameters', 'project']; };
+
+  constructor(pkg, parameters, project) {
+    this.package = pkg;
+    this.parameters = parameters;
+    this.project = project;
+  }
+
+  execute(metadata) {
+    return Promise.resolve(this.patches(metadata.patches))
+      .then(() => this.dependencies(metadata.dependencies))
+      .then(() => this.bundles(metadata.bundles))
+      .then(() => this.tasks(metadata.tasks))
+      .then(() => this.scripts(metadata.scripts))
+      .then(() => this.project.writeAureliaJSON());
+  }
+
+  patches(instructions) {
+    if (!instructions || instructions.length === 0) {
+      return;
+    }
+
+    this.project.applyPatch(instructions);
+  }
+
+  dependencies(metadataDependencies) {
+    if (!metadataDependencies || metadataDependencies.length === 0) {
+      return;
+    }
+
+    let targetBundle = this.project.getBundle(this.parameters.bundle);
+    
+    if (!targetBundle) {
+      throw new Error(`Could not find target bundle: ${this.parameters.bundle}`);
+    }
+
+    logger.info(`Adding/removing dependencies to the '${targetBundle.name}' bundle`);
+
+    for (let metadataDep of metadataDependencies) {
+      let name = metadataDep.name || metadataDep;
+      let existingDependency = this.project.getDependency(targetBundle, name);
+
+      if (this.parameters.action === 'install') {
+        if (!existingDependency) {
+          this.project.addDependency(targetBundle, metadataDep);
+          logger.info(`The '${name}' dependency has been added.`);
+        } else {
+          this.project.replaceDependency(targetBundle, existingDependency, metadataDep);
+          logger.info(`The '${name}' dependency has been modified.`);
+        }
+      } else if (this.parameters.action === 'uninstall') {
+        this.project.removeDependency(targetBundle, dependency);
+        logger.info(`The '${name}' dependency has been removed.`);
+      }
+    }
+  }
+
+  bundles(bundles) {
+    if(!bundles || bundles.length === 0) {
+      logger.debug('No bundles need to be created');
+      return;
+    }
+
+    logger.info(`Bundles found. Creating new bundles in aurelia.json...`);
+    for (let bundle of bundles) {
+      let existingBundle = this.project.getBundle(bundle.name);
+
+      if (this.parameters.action === 'install') {
+        if (!existingBundle) {
+            this.project.addBundle(bundle);
+            logger.info(`Bundle '${bundle.name}' has been created.`);
+        } else {
+          this.project.replaceBundle(existingBundle, bundle);
+          logger.info(`Bundle '${bundle.name}' has been modified.`);
+        }
+      } else if (this.parameters.action === 'uninstall') {
+        this.project.removeBundle(bundle);
+        logger.info(`Bundle '${bundle.name}' has been removed.`);
+      }
+    }
+  }
+
+  scripts(instructions) {
+    if (!instructions || instructions.length === 0) {
+      return;
+    }
+
+    try {
+      let scripts = instructions[this.parameters.action];
+
+      if (scripts && scripts.length > 0) {
+        logger.info(`Scripts found. Executing...`);
+        for (let script of scripts) {
+          logger.info(`Executing: ${script}`);
+          execSync(script, {stdio:[0,1,2]})
+        }
+      }
+
+      logger.info(`Scripts finished successfully.`);
+    } catch (e) {
+      logger.error(`An error occurred during script execution.`, e.message);
+    }
+  }
+
+  tasks(tasks) {
+    if (!tasks || tasks.length === 0) {
+      logger.debug(`No tasks have to be created`);
+      return;
+    }
+
+    logger.info(`${tasks.length} custom task(s) found. Copying to aurelia_project/tasks folder...`);
+
+    let projectFolder = 'aurelia_project/',
+        fileExtension = this.project.getAureliaJSON().transpiler.fileExtension,
+        destFolder = `${projectFolder}tasks/`;
+
+    for (let taskName of tasks) {
+      // determinate transpiler to set correct file extension
+      let filename = taskName + fileExtension,
+          destFile = destFolder + filename,
+          source = null;
+
+      try {
+        // by default, search in installed package directory
+        let pkgName = this.parameters.package;
+        pkgName = pkgName.indexOf('@') !== -1 ? pkgName.split('@')[0] : pkgName;
+        source = join(this.package.pluginPath, 'tasks', taskName);
+        copySync(`${source}.js`, destFile);
+      } catch (err) {
+        logger.error(`Could not copy the '${taskName}' task from '${source}' to '${destFile}`, err);
+      }
+
+      // task metadata is optional
+      try {
+        let fileInfo = statSync(`${source}.json`);
+        if (fileInfo.isFile()) {
+          copySync(`${source}.json`, `${dest + taskName}.json`);
+        }
+      } catch (err) {
+        if (err.code !== 'ENOENT') {
+          logger.error(`Error while copying task metadata '${source}.json': `, err);
+        }
+      }
+
+      logger.info(`Custom task: ${taskName} has been installed.`);
+    }
+
+    logger.info(`Custom tasks have been installed successfully.\n`);
+  }
+}
+
+module.exports = MetadataService;

--- a/lib/importer/services/registry.js
+++ b/lib/importer/services/registry.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const fs = require('../../file-system'),
+      semver = require('semver');
+
+let Registry = class {
+  getPackageConfig(pkg, version) {
+    let folder = fs.join(__dirname, `../registry/${pkg.name}`);
+
+    if (!fs.existsSync(folder)) {
+      return Promise.resolve(null);
+    }
+
+    return this._getAvailableVersions(folder)
+    .then(files => this._findBestMatch(files, version))
+    .then(match => {
+      if (!match) {
+        return Promise.resolve(null);
+      }
+
+      return fs.readFile(fs.join(folder, match + '.json'));
+    }).then(contents => JSON.parse(contents));
+  }
+
+  _getAvailableVersions(folder) {
+    return fs.readdir(folder)
+    .then(files => {
+      return files.map(x => x.replace('.json', ''));
+    });
+  }
+
+  // find the closest matching version to the target
+  // but not anything above the target version
+  _findBestMatch(versions, target) {
+    let bestMatch;
+
+    let validVersions = versions.filter(x => semver.valid(x));
+
+    for(let i = 0; i < validVersions.length; i++) {
+      let version = validVersions[i];
+
+      if (semver.eq(version, target)) {
+        return version;
+      }
+
+      if (semver.lt(version, target)) {
+        if (!bestMatch || semver.gt(version, bestMatch)) {
+          bestMatch = version;
+        }
+      }
+    }
+
+    return bestMatch;
+  }
+};
+
+module.exports = Registry;

--- a/lib/importer/services/resource-inclusion.js
+++ b/lib/importer/services/resource-inclusion.js
@@ -1,0 +1,71 @@
+"use strict";
+
+const UI = require('../../ui').UI,
+      path = require('path'),
+      glob = require('glob');
+
+let ResourceInclusion = class {
+
+  static inject() { return [UI, 'package']; };
+
+  constructor(ui, pkg) {
+    this.ui = ui;
+    this.package = pkg;
+  }
+
+  getCSS() {
+    let globExpr = '?(dist|build|lib|css|style|styles})/**/*.css';
+
+    return this.getResources(globExpr)
+    .then(cssFiles => {
+      if (cssFiles.length === 0) {
+        return [];
+      }
+
+      let question = `The importer has found ${cssFiles.length} css file(s). Do you want to include some?`;
+      let options = [
+        {
+          displayName: 'Yes',
+          description: 'I want choose which css files I need'
+        },
+        {
+          displayName: 'No',
+          description: 'I do not need css files'
+        }
+      ];
+      return this.ui.question(question, options)
+      .then(answer => {
+        if (answer.displayName === 'Yes') {
+          let options = cssFiles.map(x => { 
+            return {
+              displayName: x
+            };
+          });
+
+          return this.ui.multiselect('What files do you need?', options)
+          .then(answers => answers.map(x => x.displayName));
+        }
+
+        return [];
+      });
+    });
+  }
+
+  getResources(globExpr) {
+    return this.glob(globExpr, { cwd: this.package.rootPath })
+    .then(files => files.map(file => path.posix.join(file)));
+  }
+
+  glob(globExpr, options) {
+    return new Promise((resolve, reject) => {
+      glob(globExpr, options, function (er, files) {
+        if (er) {
+          reject(er);
+        }
+        resolve(files);
+      });
+    });
+  }
+};
+
+module.exports = ResourceInclusion;

--- a/lib/importer/services/tutorial.js
+++ b/lib/importer/services/tutorial.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const logger = require('aurelia-logging').getLogger('Tutorial');
+
+module.exports = class {
+  static inject() { return ['registry', 'package']; }
+
+  constructor(registry, pkg) {
+    this.registry = registry;
+    this.package = pkg;
+  }
+
+  start(metadata) {
+    return Promise.resolve(this.getTutorial(metadata))
+    .then(tutorial => {
+      logger.info('*********** Tutorial ***********');
+
+      if (tutorial) {
+        for(let line of tutorial) {
+          logger.info(line);
+        }
+      } else {
+        logger.info(`Are you the maintainer of ${this.package.name} and would you like to define a tutorial that is displayed here?`);
+        logger.info(`In order to do so you can add an "aurelia"."import"."tutorial" section to the package.json of ${this.package.name}. This can be set to an array of strings.`);
+      }
+
+      if (metadata && metadata.dependencies) {
+
+        let dependenciesWithResources = 
+          metadata.dependencies.filter(x => x.resources && x.resources.length > 0);
+
+        if (dependenciesWithResources.length > 0) {
+          
+          logger.info('*********** Using resources ***********');
+
+          for(let dep of dependenciesWithResources) {
+            logger.info(`${dep.name} has resources. The following require statements can be used to load these resources:`);
+
+            for(let resource of dep.resources) {
+              logger.info(`<require from="${dep.name}/${resource}"></require>`);
+            }
+          }
+        }
+      }
+      
+      logger.info('*********** Importing the module ***********');
+      logger.info('The following import statements are possible:');
+      logger.info(`import '${this.package.name}';`);
+      logger.info(`import ${this.package.name} from '${this.package.name}';`);
+      logger.info(`import * as ${this.package.name} from '${this.package.name}';`);
+      logger.info('We are looking into ways to detect what is the right one');
+      logger.info('*********** End of tutorial ***********');
+    });
+  }
+
+  getTutorial(metadata) {
+    if (metadata && metadata.tutorial) {
+      return metadata.tutorial;
+    }
+
+    let aureliaSection = this.package.packageJSON.aurelia;
+    if (aureliaSection &&
+        aureliaSection.import && 
+        typeof(aureliaSection.import === 'object') && 
+        aureliaSection.import.tutorial) {
+      return aureliaSection.import.tutorial;
+    }
+
+    return this.registry.getPackageConfig(this.package, this.package.version)
+    .then(config => {
+      if (config) {
+        return config.tutorial;
+      }
+    });
+  }
+};

--- a/lib/importer/strategies/amodro.js
+++ b/lib/importer/strategies/amodro.js
@@ -1,0 +1,94 @@
+"use strict";
+
+const readFile = require('../../file-system').readFile,
+      fs = require('../../file-system'),
+      logger = require('aurelia-logging').getLogger('Amodro'),
+      path = require('path'),
+      amodroTrace = require('../../build/amodro-trace'),
+      cjsTransform = require('../../build/amodro-trace/read/cjs');
+
+let AmodroStrategy = class {
+
+  static inject() { return ['package']; };
+
+  constructor(pkg) {
+    this.package = pkg;
+  }
+
+  applies() {
+    if (!this.package.main) {
+      logger.debug('This package did not specify a "main" file in package.json. Skipping');
+      return false;
+    }
+
+    return true;
+  }
+
+  execute() {
+    this.moduleId = this.package.getModuleId(this.package.main);
+
+    return this.trace(this.package.name, this.moduleId)
+    .then(tracedFiles => {
+      logger.debug(`The package has ${tracedFiles} dependency file(s).`);
+
+      if (tracedFiles === 0) {
+        throw new Error(`Could not trace '${this.package.main}' of the '${this.package.name}' package. There were 0 traced files`);
+      }
+            
+      return this.package.detectResources()
+      .then(() => {
+         if(tracedFiles > 1 || this.package.resources.length > 0) {
+          logger.debug('Using multi file configuration for this package.');
+        } else {
+          logger.debug('Using single file configuration for this package.');
+          this.package.main = null;
+          this.package.path = path.posix.join('../node_modules/', this.package.name, this.moduleId);
+        }
+      });
+    })
+    .then(() => {
+      return {
+        dependencies: [this.package.getConfiguration()]
+      };
+    });
+  }
+
+  trace(packageName, moduleId) {
+    let rootDir = path.join(process.cwd(), 'node_modules', packageName);
+
+    let existingFilesMap = {};
+
+    return amodroTrace(
+      {
+        rootDir: rootDir,
+        id: moduleId,
+        fileRead: function(defaultRead, id, filePath) {
+          if (fs.existsSync(filePath)) {
+            existingFilesMap[filePath] = true;
+            let contents = fs.readFileSync(filePath).toString();
+
+            return contents;
+          }
+
+          existingFilesMap[filePath] = false;
+          
+          return '';
+        },
+        readTransform: function(id, url, contents) {
+          return cjsTransform(url, contents);
+        }
+      }
+    ).then(traceResult => {
+      let traced = traceResult.traced;
+      let found = traced.filter(x => existingFilesMap[x.path]);
+
+      return found.length;
+    });
+  }
+
+  get name() {
+    return 'Amodrotrace Strategy';
+  }
+};
+
+module.exports = AmodroStrategy;

--- a/lib/importer/strategies/aurelia-registry.js
+++ b/lib/importer/strategies/aurelia-registry.js
@@ -1,0 +1,44 @@
+"use strict";
+
+const semver = require('semver'),
+      logger = require('aurelia-logging').getLogger('Registry');
+
+let AureliaRegistryStrategy = class {
+
+  static inject() { return ['package', 'registry']; };
+
+  constructor(pkg, registry) {
+    this.package = pkg;
+    this.registry = registry;
+  }
+
+  applies() {
+    let version = semver.clean(this.package.version);
+
+    return this.registry.getPackageConfig(this.package, version)
+    .then(config => {
+      if (config) {
+        this.config = config;
+        return this.isUsableConfig(config);
+      } else {
+        logger.debug(`The registry does not contain a package configuration for ${this.package.name}`);
+        return false;
+      }
+    });
+  }
+
+  execute() {
+    return this.config;
+  }
+
+  isUsableConfig(c) {
+    let props = ['patches', 'dependencies', 'bundles', 'tasks', 'scripts'];
+    return Object.keys(c).some(key => props.includes(key));
+  }
+
+  get name() {
+    return 'Registry Strategy';
+  }
+};
+
+module.exports = AureliaRegistryStrategy;

--- a/lib/importer/strategies/browser-section.js
+++ b/lib/importer/strategies/browser-section.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const logger = require('aurelia-logging').getLogger('Browser');
+
+let BrowserSectionStrategy = class {
+
+  static inject() { return ['package']; };
+
+  constructor(pkg) {
+    this.package = pkg;
+  }
+
+  applies() {
+    if (!this.hasBrowserSection(this.package.packageJSON)) {
+      logger.debug(`There is no (usable) "browser" section in the package.json file of the plugin (looked in '${this.package.packageJSONPath}')`);
+      return false;
+    }
+
+    return true;
+  }
+
+  execute() {
+    let browser = this.package.packageJSON.browser;
+    this.package.main = this.package.getModuleId(browser);
+      
+    return this.package.detectResources()
+    .then(() => {
+      return {
+        dependencies: [this.package.getConfiguration()]
+      };
+    });
+  }
+
+  hasBrowserSection(packageJSON) {
+    return packageJSON.browser && typeof packageJSON.browser === 'string';
+  }
+
+  get name() {
+    return 'Browser Section Strategy';
+  }
+};
+
+module.exports = BrowserSectionStrategy;

--- a/lib/importer/strategies/custom-importer.js
+++ b/lib/importer/strategies/custom-importer.js
@@ -1,0 +1,61 @@
+"use strict";
+
+const fs = require('../../file-system'),
+      Container = require('aurelia-dependency-injection').Container,
+      logger = require('aurelia-logging').getLogger('Custom-importer');
+
+let CustomImporterStrategy = class {
+
+  static inject() { return [Container, 'package']; };
+
+  constructor(container, pkg) {
+    this.container = container;
+    this.package = pkg;
+  }
+
+  applies() {
+    let location = this.getStrategyLocation();
+
+    return fs.exists(location)
+    .then(available => {
+      if (available) {
+        let strategy = this.getStrategy();
+        let result = strategy.applies();
+
+        return result;
+      }
+
+      logger.debug(`The plugin does not have a custom importer module. Looked for "${location}"`);
+
+      return false;
+    });
+  }
+
+  execute() {
+    let strategy = this.getStrategy();
+    let result = strategy.execute();
+
+    return result;
+  }
+
+  getStrategy() {
+    let ctor = require(this.getStrategyLocation());
+    return this.container.get(ctor);
+  }
+
+  getStrategyLocation() {
+    let pjson = this.package.packageJSON;
+
+    if (pjson.aurelia && (typeof pjson.aurelia.import === 'string')) {
+      return fs.resolve(fs.join(this.package.rootPath, pjson.aurelia.import));
+    }
+
+    return fs.resolve(fs.join(this.package.rootPath, 'install', 'importer-callbacks.js'));
+  }
+
+  get name() {
+    return 'Custom Importer Strategy';
+  }
+};
+
+module.exports = CustomImporterStrategy;

--- a/lib/importer/strategies/jspm-section.js
+++ b/lib/importer/strategies/jspm-section.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const logger = require('aurelia-logging').getLogger('JSPM'),
+      path = require('path');
+
+let JSPMSectionStrategy = class {
+
+  static inject() { return ['package']; };
+
+  constructor(pkg) {
+    this.package = pkg;
+  }
+
+  applies() {
+    if (!this.hasJSPMConfig(this.package.packageJSON)) {
+      logger.debug(`There is no "jspm" section in the package.json file of the plugin (looked in '${this.package.packageJSONPath}')`);
+      return false;
+    }
+
+    return true;
+  }
+
+  execute() {
+    let jspm = this.package.packageJSON.jspm;
+    let directories = jspm.directories;
+    let distFolder = '';
+
+    if(directories) {
+      distFolder = directories.dist || directories.lib;
+    }
+
+    this.package.path = path.posix.join('../node_modules/', this.package.name, distFolder);
+    this.package.main = jspm.main;
+
+    if (jspm.shim && jspm.shim[configuration.main]) {
+      let shim = jspm.shim[configuration.main];
+      this.package.deps = shim.deps;
+      this.package.exports = shim.exports;
+    }
+      
+    return this.package.detectResources()
+    .then(() => {
+      return {
+        dependencies: [this.package.getConfiguration()]
+      };
+    });
+  }
+
+  hasJSPMConfig(packageJSON) {
+    return packageJSON.jspm;
+  }
+
+  get name() {
+    return 'JSPM Section Strategy';
+  }
+};
+
+module.exports = JSPMSectionStrategy;

--- a/lib/importer/strategies/metadata.js
+++ b/lib/importer/strategies/metadata.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const logger = require('aurelia-logging').getLogger('Metadata');
+
+let MetadataStrategy = class {
+
+  static inject() { return ['package']; };
+
+  constructor(pkg) {
+    this.package = pkg;
+  }
+
+  applies() {
+    if (!this.hasMetadata(this.package.packageJSON)) {
+      logger.debug(`There is no "aurelia"."import" section in the package.json file of the plugin (looked in "${this.package.packageJSONPath}")`);
+      return false;
+    }
+
+    return true;
+  }
+
+  execute() {
+    let metadata = this.getMetadata(this.package.packageJSON);
+
+    return metadata;
+  }
+
+  getMetadata(packageJSON) {
+    return packageJSON.aurelia.import;
+  }
+
+  hasMetadata(packageJSON) {
+    return packageJSON.aurelia !== undefined && 
+           packageJSON.aurelia.import !== undefined && 
+           typeof packageJSON.aurelia.import === 'object';
+  }
+
+  get name() {
+    return 'Metadata Strategy';
+  }
+};
+
+module.exports = MetadataStrategy;

--- a/lib/importer/strategy-loader.js
+++ b/lib/importer/strategy-loader.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const fs = require('../file-system'),
+      Container = require('aurelia-dependency-injection').Container;
+
+let StrategyLoader = class {
+
+  static inject() { return [Container] };
+
+  constructor(container) {
+    this.container = container;
+  }
+
+  getStrategies() {
+    let files = [
+      'metadata',
+      'custom-importer',
+      'aurelia-registry',
+      'jspm-section',
+      'browser-section',
+      'amodro'
+    ];
+    let strategies = [];
+
+    for(let file of files) {
+      let path = fs.join(__dirname, 'strategies', file);
+      let ctor = require(path);
+      let strategy = this.container.get(ctor);
+
+      strategies.push(strategy);
+    }
+
+    return strategies;
+  }
+};
+
+
+module.exports = StrategyLoader;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,36 @@
+const UI = require('./ui').UI;
+
+exports.Logger = class {
+
+  static inject() { return [UI]; }
+  
+  constructor(ui) {
+    this.ui = ui;
+  }
+
+  debug(logger, message, ...rest){
+    this.log(logger, 'DEBUG', message, rest);
+  }
+
+  info(logger, message, ...rest){
+    this.log(logger, 'INFO', message, rest);
+  }
+
+  warn(logger, message, ...rest){
+    this.log(logger, 'WARN', message, rest);
+  }
+
+  error(logger, message, ...rest){
+    this.log(logger, 'ERROR', message, rest);
+  }
+
+  log(logger, level, message, rest) {
+    let msg = `${level} [${logger.id}] ${message}`;
+
+    if (rest.length > 0) {
+      msg += ` ${rest.map(x => JSON.stringify(x)).join(' ')}`;
+    }
+
+    this.ui.log(msg);
+  }
+};

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -1,0 +1,50 @@
+"use strict";
+
+let isLoaded = false;
+
+exports.NPM = class {
+  install(packages, npmOptions) {
+    npmOptions = npmOptions || {};
+    const npm = require('npm');
+
+    let originalWorkingDirectory = process.cwd();
+    process.chdir(npmOptions.workingDirectory || process.cwd());
+
+    return load(npm, npmOptions)
+      .then(() => {
+        return new Promise((resolve, reject) => {
+          npm.commands.install(packages, error => {
+            process.chdir(originalWorkingDirectory);
+
+            if (error) reject(error);
+            else resolve();
+          });
+        });
+      }).catch(error => {
+        process.chdir(originalWorkingDirectory);
+        throw error;
+      });
+  }
+}
+
+exports.default = exports.NPM;
+
+function load(npm, npmOptions) {
+  if (isLoaded) {
+    for(let key in npmOptions) {
+      npm.config.set(key, npmOptions[key]);
+    }
+
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    npm.load(npmOptions, error => {
+      if (error) reject(error);
+      else {
+        isLoaded = true;
+        resolve();
+      }
+    });
+  })
+}

--- a/lib/package-managers/yarn.js
+++ b/lib/package-managers/yarn.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const child_process = require('child_process');
+
+exports.yarn = class {
+  install(packages) {
+    return new Promise((resolve, reject) => {
+      let cmd = `yarn add ${packages.join(' ')}`;
+      let options = { cwd: process.cwd() };
+      
+      let installProcess = child_process.exec(cmd, options, (error, stdout, stderr) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+
+      installProcess.stdout.on('data', data => console.log(data));
+    });
+  }
+}
+
+exports.default = exports.yarn;

--- a/lib/project.js
+++ b/lib/project.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('./file-system');
 const string = require('./string');
 const ProjectItem = require('./project-item').ProjectItem;
+const rfc6902 = require('rfc6902');
 
 exports.Project = class {
   static establish(ui, dir) {
@@ -22,6 +23,7 @@ exports.Project = class {
     this.package = pack;
     this.taskDirectory = path.join(directory, 'aurelia_project/tasks');
     this.generatorDirectory = path.join(directory, 'aurelia_project/generators');
+    this.aureliaJSONPath = path.join(directory, 'aurelia_project', 'aurelia.json');
 
     this.locations = Object.keys(model.paths).map(key => this[key] = ProjectItem.directory(model.paths[key]));
     this.locations.push(this.generators = ProjectItem.directory('aurelia_project/generators'));
@@ -77,6 +79,107 @@ exports.Project = class {
   resolveTask(name) {
     let potential = path.join(this.taskDirectory, `${name}${this.model.transpiler.fileExtension}`);
     return fs.exists(potential).then(result => result ? potential : null);
+  }
+
+  addDependency(bundle, dependency) {
+    if (!bundle.dependencies) {
+      bundle.dependencies = [];
+    }
+
+    bundle.dependencies.push(dependency);
+  }
+
+  addOrReplaceDependency(bundle, dependency) {
+    let name = (dependency.name || dependency);
+    if (this.hasDependency(bundle, name)) {
+      this.replaceDependency(bundle, this.getDependency(bundle, name), dependency);
+    } else {
+      this.addDependency(bundle, dependency);
+    }
+  }
+
+  replaceDependency(bundle, oldDependency, newDependency) {
+    let index = bundle.dependencies.indexOf(oldDependency);
+
+    bundle.dependencies[index] = newDependency;
+  }
+
+  removeDependency(bundle, dependency) {
+    let index = bundle.dependencies.indexOf(dependency);
+
+    bundle.dependencies.splice(index, 1);
+  }
+
+  getDependency(bundle, name) {
+    return (bundle.dependencies || []).find(item => (item.name || item) === name);
+  }
+
+  hasDependency(bundle, name) {
+    return this.getDependency(bundle, name) !== undefined;
+  }
+
+  hasBundle(bundleName) {
+    return this.getBundle(bundleName) !== undefined;
+  }
+
+  getBundle(bundleName) {
+    let bundles = this.model.build.bundles;
+    return bundles.find(item => item.name === bundleName);
+  }
+
+  addBundle(bundle) {
+    let bundles = this.model.build.bundles;
+    
+    bundles.push(bundle);
+  }
+
+  removeBundle(bundle) {
+    let bundles = this.model.build.bundles;
+    let index = bundles.indexOf(bundle);
+
+    bundles.splice(index, 1);
+  }
+
+  replaceBundle(oldBundle, newBundle) {
+    let bundles = this.model.build.bundles;
+    let index = bundles.indexOf(oldBundle);
+
+    bundles[index] = newBundle;
+  }
+
+  getDefaultBundle() {
+    let bundles = this.model.build.bundles;
+
+    if (bundles.length === 0) {
+      throw new Error('There are no bundles in aurelia.json. Please create one');
+    }
+
+    return this.getLargestBundle(bundles);
+  }
+
+  getLargestBundle(bundles) {
+    let largest;
+
+    for(let i = 0; i < bundles.length; i++) {
+      if (!largest || (bundles[i].dependencies || []).length > (largest.dependencies || []).length) {
+        largest = bundles[i];
+      }
+    }
+
+    return largest;
+  }
+
+  writeAureliaJSON() {
+    return fs.writeFile(this.aureliaJSONPath, JSON.stringify(this.model, null, 2), 'utf8');
+  }
+
+  applyPatch(instructions) {
+    let result = rfc6902.applyPatch(this.model, instructions);
+    let errors = result.filter(err => err !== null);
+
+    if (errors.length > 0) {
+      throw new Error(`An error occurred while patching aurelia.json.\nErrors: ${errors}`);
+    }
   }
 }
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -88,6 +88,22 @@ exports.ConsoleUI = class {
     });
   }
 
+  multiselect(question, options) {
+    return new Promise(resolve => {
+      let info = 'Select one or more options separated by spaces';
+      let fullText = os.EOL + question + os.EOL
+          + createOptionsText(this, options, true) + os.EOL + info + os.EOL + '> ';
+
+      this.open();
+      this.rl.question(fullText, answer => {
+        this.close();
+        let answers = answer.split(' ');
+        answers = answers.filter(x => x.length > 0);
+        resolve(interpretAnswers(answers, options));
+      });
+    });
+  }
+
   getWidth() {
     return getWindowSize().width;
   }
@@ -133,19 +149,22 @@ function includeOption(cliOptions, option) {
   return true;
 }
 
-function createOptionsText(ui, options) {
+function createOptionsText(ui, options, multi) {
   let text = os.EOL;
 
   for(let i = 0; i < options.length; ++i) {
     text += `${i + 1}. ${options[i].displayName}`;
 
-    if (i == 0) {
+    if (!multi && i == 0) {
       text += ' (Default)';
     }
 
     text += os.EOL;
-    text += createLines(`<dim>${options[i].description}</dim>`, '   ', ui.getWidth());
-    text += os.EOL;
+
+    if (options[i].description) {
+      text += createLines(`<dim>${options[i].description}</dim>`, '   ', ui.getWidth());
+      text += os.EOL;
+    }
   }
 
   return transform(text);
@@ -165,6 +184,28 @@ function interpretAnswer(answer, options) {
 
   let num = parseInt(answer);
   return options[num - 1] || options[0];
+}
+
+function interpretAnswers(answers, options) {
+  let foundAnswers = [];
+
+  for(let i = 0; i < answers.length; i++) {
+    let lowerCasedAnswer = answers[i].toLowerCase();
+    let found = options.find(x => x.displayName.toLowerCase().startsWith(lowerCasedAnswer));
+
+    if (found) {
+      foundAnswers.push(found);
+      continue;
+    }
+
+    let num = parseInt(answers[i]);
+
+    if (options[num - 1]) {
+      foundAnswers.push(options[num - 1]);
+    }
+  }
+
+  return foundAnswers;
 }
 
 function getWindowSize() {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,12 @@
   },
   "dependencies": {
     "aurelia-dependency-injection": "^1.0.0",
+    "aurelia-logging": "^1.2.0",
     "aurelia-polyfills": "^1.0.0",
-    "npm": "^3.10.8"
+    "glob": "^7.1.1",
+    "npm": "^3.10.8",
+    "rfc6902": "^1.2.2",
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "aurelia-tools": "^0.2.2"


### PR DESCRIPTION
This pull request aims to add package importer functionality to the cli. For a quick visualization of the changes in this PR we have made a small video which can be viewed [here](http://www.screencast.com/t/kZmu1S436Iw).

# 1. Definition of terms
**Install** - The term install refers to the process of fetching a package from a remote registry (npm) and copying it to the local storage ( `node_modules` )

**Import** - Add configuration to the aurelia.json file so that an already installed package can be used with aurelia-cli

# 2. Commands
Two new commands will be added to aurelia-cli:

1. `au import <package>`
  When running this command the importer module will import an already installed package for use.

   Example usage:
   1. `npm install aurelia-dialog` (or yarn)
   2. `au import aurelia-dialog`

2. `au install <package>`
   When running `au install <package>` the package will be installed (through npm/yarn) and will be imported afterwards.

   Example usage:
   1. `au install aurelia-dialog`

Both commands support the `--debug` flag.

# 3. Installing the fork
1. `git clone https://github.com/monterey-framework/cli.git`
2. `cd cli`
3. `git fetch`
4. `git checkout feat/import`
5. `npm install`
6. `npm install esprima babel-polyfill babel-register`
7. `npm install git+https://git@github.com/gulpjs/gulp.git#4.0`
8. `npm link`
9. `cd ..`
10. `au new` and use defaults
11. `cd aurelia-app`
12. `npm link aurelia-cli`

# 4. Flow
[Open in new tab](https://cloud.githubusercontent.com/assets/2189477/20866751/a2f0a798-ba34-11e6-837c-2fffb7f17e2f.png)
![img](https://cloud.githubusercontent.com/assets/2189477/20866751/a2f0a798-ba34-11e6-837c-2fffb7f17e2f.png)

The importer will first determine whether to install the package or just configure it (based on whether the `au import` command or the `au install` command is used). Then the importer will run through a list of (currently) 6 importer strategies. When a strategy is unable to "handle" the configuration of the plugin, it proceeds to the next strategy on the list.

After the best possible importer strategy has been found, the importer strategy does its thing. Then, the user is notified of which strategy has been used to configure the plugin.

After the plugin has been configured, the importer will look in the importer section of the `package.json` file. If there is a `tutorial` field, the contents of the field (which is an array of strings) will be printed.

# 5. Strategies

Currently 6 different importer strategies were implemented. Four of these strategies will be integrated in the importer and cannot be modified by plugin authors. Plugin authors can create instructions for the remaining two strategies. This is explained below.

## Metadata in package.json

There are two ways for plugin authors to instruct the aurelia-cli importer.

First, in the `aurelia` section of the package.json file, plugin authors can add an `import` section. When the aurelia-cli importer detects this section, it will execute the instructions within.

Full-featured example of `package.json`:

```
{
  "name": "my-plugin",
  "aurelia": {
    "import": {
      "patches": [
        { "op": "replace", "path": "/build/loader/plugins/0/stub", "value": false}
      ],
      "dependencies": [],
      "bundles": [
        ...
      ],
      "tasks": [
        "prepare-materialize"
      ],
      "scripts": {
        "install": [
          "au prepare-materialize",
          "node node_modules/requirejs/bin/r.js -o tools/rbuild.js"
        ]
      },
      "tutorial": [
        "1. in main.js add .plugin('aurelia-materialize-bridge')"
      ]
      }
    }
  }
}
```

### Sections:

**[patches]**

Apply patches to `aurelia.json` using RFC6902 standard.

**[dependencies]**

Append new dependency configurations to the default/specified `bundle.dependencies` array.

**[bundles]**

Add new bundles or even override an entire, existing bundle.

**[tasks]**

Copy custom CLI-tasks from package folder into `aurelia_project/tasks` folder.

**[scripts]**

You can execute any number or type of node scripts as needed.

**[tutorial]**

Allows plugin authors to explain to the user how the plugin can be used.

## Custom importer strategy
Plugin authors may find that adding importer instructions to the package.json file is not sufficient. In this case the plugin author can create an `importer-callbacks.js` file.

This `importer-callbacks.js` file could look like this:


```
class ImporterCallbacks {

 static inject() { return ['ui']; };

 constructor(ui) { }

 /**
 * Determine whether this particular strategy can be used or not
 * @returns {boolean}
 */
 determine() {
  return true;
 }

 /**
 * Main entry point called by ImportEngine
 */
 execute() {
  return {
   dependencies: [{
    name: "my-plugin",
    path: "../node_modules/my-plugin",
    main: "index.js"
   }]
  };
 }

 /**
 * Short description display in CLI output
 * @returns {string}
 */
 get name() {
  return 'Custom Importer Strategy';
 }
}
```

Whenever the importer encounters an `importer-callbacks.js` file, it loads the file. If `determine()` returns `true` the importer will call the `execute()` method.

The return value of `execute()` is metadata that is equivalent to what can be defined in the `"aurelia"."import"` section of the plugin's package.json.

# 6. Changes to the CLI
1. aurelia-logger was added to `lib/cli.js`, and the existence of the `--debug` flag determines whether the loglevel is info or debug. `lib/logger.js` is the custom logger for the cli, which always uses `console.log` since `console.info` etc are unavailable.
2. A couple of methods were added to `lib/file-system.js`: existsSync, copySync, resolve, join, statSync
3. The `package-managers` folder was added, containing both the `npm` and the `yarn` implementation of `install(packages, options)`
4. The `aureliaJSONPath` is now set on the Project (`lib/project.js`)
5. The `multiselect()` function was added to `ui.js` to allow a user to select multiple CSS resources at once.
6. The following dependencies were added:
- aurelia-logging
- bluebird
- node-glob (search for .css files in a package)
- rfc6902 (to patch aurelia.json via rfc6902)
- semver (to find the closest matching version of a package configuration in the cli's registry)


# 7. Additional CLI Feature suggestions:

### 7.1 Extending `au new` wizard steps with "Choose default package manager" option:

A new field has been added to `aurelia.json` called `packageManager` of which the default value is 'npm' (and 'yarn' is supported). Currently there is no way to change this value other than opening the aurelia.json file in a text editor and manually patching the value.

A new question could be added to the `au new` wizard asking the user which package manager should be used for the new project. The default should be 'npm' here, as not everyone has `yarn` installed.

### 7.2 Using npms (https://npms.io) services to search npm registry
While this functionality works best in Monterey GUI context, where:

1. User starts typing into the `autocomplete` box, which finds the package in real time using **[npms API](https://api-docs.npms.io/)** and populates the list of available version numbers
2. User selects the version number (current version is selected by default).
3. Actions 1. and 2. together enable the `Add this pair` button
4. Click on `Add this pair` button adds a package to the list of packages to be imported.

<p align=center>
<img src="https://cloud.githubusercontent.com/assets/2712405/21573689/73519b42-ceb5-11e6-9ddf-bb5eb9ec4239.png"></img>
<br><br>
</p>

we plan to make a similar, properly restricted service available to Aurelia CLI application as well. See **[Provide npms based package search](https://github.com/monterey-framework/cli/issues/28)** for more information.


### 7.3 Assisting the user in the process of accessing the imported a package.

While testing the initial importer code, we made a random **[selection of packages](https://github.com/monterey-framework/cli/issues/12)** and encountered many problems trying to invoke the code from the package. So, we came up with the idea to advice / intelligence / proactive support for the developer that has "installed" and "imported" a package and then sits stupefied pondering how to invoke the code from his app.

For most packages there is a two step process for importing package:

**Loading CSS**

The importer can detect css files in packages and add them to the `resources` property in a dependency configuration. A good example is `flatpickr`:
```
{
"name": "flatpickr",
"path": "../node_modules/flatpickr",
"resources": [
"dist/flatpickr.css"
],
"main": "dist/flatpickr.js"
}
```

The user can load the css file with: `<require from="flatpickr/dist/flatpickr.css"></require>`. The importer provides this require statement so that the user only needs to copy and paste it into an html file.

**Loading Javascript**

There are many different kinds of import statements, leaving the developer to guess which one is the right one.

```
import 'flatpickr';
import flatpickr from 'flatpickr';
import * as flatpickr from 'flatpickr';
```

We would like to investigate whether it is possible to detect which import statement could be used to import the javascript portion of a package.

### 7.4 Backup and restore
Before modifying the aurelia.json file we can create a backup. Then, with `au import --revert` we can revert to the previous aurelia.json file.

# 8. Todo
1. See what services custom importers could need (and create custom importers for aurelia-i18n, aurelia-kendoui-bridge and aurelia-materialize-bridge)

2. Take a closer look at [these issues](https://github.com/monterey-framework/cli/issues/27)

# 9. Questions
1. Should the single file dependency configuration only be used when there no `resources` either? The path is calculated incorrectly since the `path` is a reference to a file and not to a directory.

2. Should we use `lib/ui.js` to log messages, or can we keep using `aurelia-logging`? The importer logs messages of type `info` and `debug`
3. Does the bundler support the system module format? A plugin can configure its `dist` directory to point to `dist/system`, and the importer will configure the dependency using the `dist/system` directory.
```
"jspm": {
   "directories": {
      "dist": "dist/system"
   }
}
```

