### PR TITLE
fix(dependency-inclusion): wait until all resources are traced before bundling

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -39,9 +39,7 @@ exports.Bundle = class {
     )
     // Add dependencies in the same order as they were entered
     // to prevent a wrong module load order.
-    .then(descriptions => 
-      descriptions.forEach(description => 
-        bundle.addDependency(description)))
+    .then(descriptions => Promise.all(descriptions.map(dep => bundle.addDependency(dep))))
     .then(() => bundle);
   }
 


### PR DESCRIPTION
It seems as if the latest CLI version (this commit: https://github.com/aurelia/cli/commit/100e9f6a9f5de31e3d3f58abdee705b6e22365dc) introduced a regression with a PR created earlier by @JeroenVinke (this one: https://github.com/aurelia/cli/pull/369).

If the user defined the `resources` array like so:
```javascript
"resources": [
  "**/*.{css,html}"
]
```

not all resource files would be included in the bundle because the trace stopped prematurely.

The behaviour described in this PR occured again for aurelia-materialize-bridge and aurelia-kendoui-bridge. 

I've tested this change with a reproduction of the repo that led to this PR: https://github.com/aurelia/cli/pull/363
