### PR TITLE
feat(bundle): add support for 'append' property in bundle config

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -13,6 +13,7 @@ exports.Bundle = class {
     this.config = config;
     this.dependencies = [];
     this.prepend = (config.prepend || []).filter(x => bundler.itemIncludedInBuild(x));
+    this.append = (config.append || []).filter(x => bundler.itemIncludedInBuild(x));
     this.moduleId = config.name.replace(path.extname(config.name), '');
     this.hash = '';
     this.includes = (config.source || []);
@@ -119,9 +120,13 @@ exports.Bundle = class {
       });
     }
 
-    return work.then(() => {
-      files = files.concat(this.getBundledFiles());
+    work = work.then(() => files = files.concat(this.getBundledFiles()));
 
+    if(this.append.length) {
+      work = work.then(() => addFilesInOrder(this, this.append, files));
+    }
+
+    return work.then(() => {
       const Concat = require('./concat-with-sourcemaps');
       let concat = new Concat(true, this.config.name, os.EOL);
       const generateHashedPath = require('./utils').generateHashedPath;


### PR DESCRIPTION
Just a copy of the 'prepend' logic to allow appending files to the end of a bundle. Useful for legacy (non-amd) Javascript library plugins which require the global object defined in the 'main' library script to be available when the plugin scripts execute.
