### PR TITLE
fix(copy-files): copy files when building for production

### DIFF
--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -117,7 +117,6 @@ exports.ProjectTemplate = class {
       ProjectItem.resource('build.ext', 'tasks/build.ext', this.model.transpiler),
       ProjectItem.resource('build.json', 'tasks/build.json'),
       ProjectItem.resource('copy-files.ext', 'tasks/copy-files.ext', this.model.transpiler),
-      ProjectItem.resource('copy-files.json', 'tasks/copy-files.json'),
       ProjectItem.resource('run.ext', 'tasks/run.ext', this.model.transpiler),
       ProjectItem.resource('run.json', 'tasks/run.json')
     ).addToGenerators(

--- a/lib/resources/tasks/build.js
+++ b/lib/resources/tasks/build.js
@@ -2,6 +2,7 @@ import gulp from 'gulp';
 import transpile from './transpile';
 import processMarkup from './process-markup';
 import processCSS from './process-css';
+import copyFiles from './copy-files';
 import {build} from 'aurelia-cli';
 import project from '../aurelia.json';
 
@@ -10,7 +11,8 @@ export default gulp.series(
   gulp.parallel(
     transpile,
     processMarkup,
-    processCSS
+    processCSS,
+    copyFiles
   ),
   writeBundles
 );

--- a/lib/resources/tasks/build.ts
+++ b/lib/resources/tasks/build.ts
@@ -2,6 +2,7 @@ import * as gulp from 'gulp';
 import transpile from './transpile';
 import processMarkup from './process-markup';
 import processCSS from './process-css';
+import copyFiles from './copy-files';
 import {build} from 'aurelia-cli';
 import * as project from '../aurelia.json';
 
@@ -10,7 +11,8 @@ export default gulp.series(
   gulp.parallel(
     transpile,
     processMarkup,
-    processCSS
+    processCSS,
+    copyFiles
   ),
   writeBundles
 );

--- a/lib/resources/tasks/copy-files.js
+++ b/lib/resources/tasks/copy-files.js
@@ -23,25 +23,21 @@ export default function copyFiles(done) {
 
 function getNormalizedInstruction() {
   const files = project.build.copyFiles;
-  let normalizedFiles = {};
+  let normalizedInstruction = {};
 
   for (let key in files) {
-    normalizedFiles[path.posix.normalize(key)] = files[key];
+    normalizedInstruction[path.posix.normalize(key)] = files[key];
   }
 
-  return normalizedFiles;
+  return normalizedInstruction;
 }
 
 function prepareFilePath(filePath) {
-  let preparedPath = filePath.replace(process.cwd(), '');
+  let preparedPath = filePath.replace(process.cwd(), '').substring(1);
 
   //if we are running on windows we have to fix the path
   if (/^win/.test(process.platform)) {
     preparedPath = preparedPath.replace(/\\/g, '/');
-  }
-
-  if (preparedPath.startsWith('/')) {
-    preparedPath = preparedPath.substring(1);
   }
 
   return preparedPath;

--- a/lib/resources/tasks/copy-files.js
+++ b/lib/resources/tasks/copy-files.js
@@ -1,20 +1,48 @@
 import gulp from 'gulp';
 import path from 'path';
+import changedInPlace from 'gulp-changed-in-place';
 import project from '../aurelia.json';
 
 export default function copyFiles(done) {
-  const filesToCopy = project.build.copyFiles;
-  if (!filesToCopy) {
+  if (typeof project.build.copyFiles !== 'object') {
     done();
     return;
   }
- 
-  for (let file in filesToCopy) {
-    const source = path.posix.join(project.paths.root, file);
-    const target = path.posix.join(project.platform.output, filesToCopy[file]);
-    console.log(`Copying ${source} to ${target}`);
-    gulp.src(source).pipe(gulp.dest(target));
+
+  const instruction = getNormalizedInstruction();
+  const files = Object.keys(instruction);
+
+  return gulp.src(files)
+    .pipe(changedInPlace({ firstPass: true }))
+    .pipe(gulp.dest(x => {
+      const filePath = prepareFilePath(x.path);
+      const key = files.find(f => f === filePath);
+      return instruction[key];
+    }));
+}
+
+function getNormalizedInstruction() {
+  const files = project.build.copyFiles;
+  let normalizedFiles = {};
+
+  for (let key in files) {
+    normalizedFiles[path.posix.normalize(key)] = files[key];
   }
- 
-  done();
+
+  return normalizedFiles;
+}
+
+function prepareFilePath(filePath) {
+  let preparedPath = filePath.replace(process.cwd(), '');
+
+  //if we are running on windows we have to fix the path
+  if (/^win/.test(process.platform)) {
+    preparedPath = preparedPath.replace(/\\/g, '/');
+  }
+
+  if (preparedPath.startsWith('/')) {
+    preparedPath = preparedPath.substring(1);
+  }
+
+  return preparedPath;
 }

--- a/lib/resources/tasks/copy-files.json
+++ b/lib/resources/tasks/copy-files.json
@@ -1,4 +1,0 @@
-{
-  "name": "copy-files",
-  "description": "Copy files from root to the output directory."
-}

--- a/lib/resources/tasks/copy-files.ts
+++ b/lib/resources/tasks/copy-files.ts
@@ -1,20 +1,48 @@
 import * as gulp from 'gulp';
 import * as path from 'path';
+import * as changedInPlace from 'gulp-changed-in-place';
 import * as project from '../aurelia.json';
 
 export default function copyFiles(done) {
-  const filesToCopy = project.build.copyFiles;
-  if (!filesToCopy) {
+  if (typeof project.build.copyFiles !== 'object') {
     done();
     return;
   }
- 
-  for (let file in filesToCopy) {
-    const source = path.posix.join(project.paths.root, file);
-    const target = path.posix.join(project.platform.output, filesToCopy[file]);
-    console.log(`Copying ${source} to ${target}`);
-    gulp.src(source).pipe(gulp.dest(target));
+
+  const instruction = getNormalizedInstruction();
+  const files = Object.keys(instruction);
+
+  return gulp.src(files)
+    .pipe(changedInPlace({ firstPass: true }))
+    .pipe(gulp.dest(x => {
+      const filePath = prepareFilePath(x.path);
+      const key = files.find(f => f === filePath);
+      return instruction[key];
+    }));
+}
+
+function getNormalizedInstruction() {
+  const files = project.build.copyFiles;
+  let normalizedFiles = {};
+
+  for (let key in files) {
+    normalizedFiles[path.posix.normalize(key)] = files[key];
   }
- 
-  done();
+
+  return normalizedFiles;
+}
+
+function prepareFilePath(filePath) {
+  let preparedPath = filePath.replace(process.cwd(), '');
+
+  //if we are running on windows we have to fix the path
+  if (/^win/.test(process.platform)) {
+    preparedPath = preparedPath.replace(/\\/g, '/');
+  }
+
+  if (preparedPath.startsWith('/')) {
+    preparedPath = preparedPath.substring(1);
+  }
+
+  return preparedPath;
 }

--- a/lib/resources/tasks/copy-files.ts
+++ b/lib/resources/tasks/copy-files.ts
@@ -23,25 +23,21 @@ export default function copyFiles(done) {
 
 function getNormalizedInstruction() {
   const files = project.build.copyFiles;
-  let normalizedFiles = {};
+  let normalizedInstruction = {};
 
   for (let key in files) {
-    normalizedFiles[path.posix.normalize(key)] = files[key];
+    normalizedInstruction[path.posix.normalize(key)] = files[key];
   }
 
-  return normalizedFiles;
+  return normalizedInstruction;
 }
 
 function prepareFilePath(filePath) {
-  let preparedPath = filePath.replace(process.cwd(), '');
+  let preparedPath = filePath.replace(process.cwd(), '').substring(1);
 
   //if we are running on windows we have to fix the path
   if (/^win/.test(process.platform)) {
     preparedPath = preparedPath.replace(/\\/g, '/');
-  }
-
-  if (preparedPath.startsWith('/')) {
-    preparedPath = preparedPath.substring(1);
   }
 
   return preparedPath;

--- a/lib/resources/tasks/run.js
+++ b/lib/resources/tasks/run.js
@@ -3,7 +3,6 @@ import browserSync from 'browser-sync';
 import historyApiFallback from 'connect-history-api-fallback/lib';
 import project from '../aurelia.json';
 import build from './build';
-import copyFiles from './copy-files';
 import {CLIOptions} from 'aurelia-cli';
 
 function log(message) {
@@ -21,7 +20,6 @@ function reload(done) {
 
 let serve = gulp.series(
   build,
-  copyFiles,
   done => {
     browserSync({
       online: false,
@@ -53,6 +51,12 @@ let watch = function() {
   gulp.watch(project.transpiler.source, refresh).on('change', onChange);
   gulp.watch(project.markupProcessor.source, refresh).on('change', onChange);
   gulp.watch(project.cssProcessor.source, refresh).on('change', onChange);
+
+  //see if there are static files to be watched
+  if (typeof project.build.copyFiles === 'object') {
+    const files = Object.keys(project.build.copyFiles);
+    gulp.watch(files, refresh).on('change', onChange);
+  } 
 };
 
 let run;

--- a/lib/resources/tasks/run.ts
+++ b/lib/resources/tasks/run.ts
@@ -49,6 +49,12 @@ let watch = function() {
   gulp.watch(project.transpiler.source, refresh).on('change', onChange);
   gulp.watch(project.markupProcessor.source, refresh).on('change', onChange);
   gulp.watch(project.cssProcessor.source, refresh).on('change', onChange);
+
+  //see if there are static files to be watched
+  if (typeof project.build.copyFiles === 'object') {
+    const files = Object.keys(project.build.copyFiles);
+    gulp.watch(files, refresh).on('change', onChange);
+  } 
 }
 
 let run;

--- a/lib/resources/tasks/run.ts
+++ b/lib/resources/tasks/run.ts
@@ -3,7 +3,6 @@ import * as browserSync from 'browser-sync';
 import * as historyApiFallback from 'connect-history-api-fallback/lib';
 import * as project from '../aurelia.json';
 import build from './build';
-import copyFiles from './copy-files';
 import {CLIOptions} from 'aurelia-cli';
 
 function onChange(path) {
@@ -17,7 +16,6 @@ function reload(done) {
 
 let serve = gulp.series(
   build,
-  copyFiles,
   done => {
     browserSync({
       online: false,


### PR DESCRIPTION
This PR resolves the problems found in https://github.com/aurelia/cli/pull/415

## Problems

**Thomas Darling wrote:**
> @fabioluz @AStoker @EisenbergEffect I have a couple of concerns about this.
> 
> > By default root is the src folder and the output is the scripts folder.
>
> I don't understand why the output is relative to the scripts folder.
> I'd very strongly prefer to have it be relative to the project output folder instead, so I don't have to write ../ when copying files that are not scripts - I think copying non-script files will be a much more common scenario for this, such as in the example above, which actually copies font files.
> 
> I'm also wondering why this task runs as part of the serve task - that's for development only, so this won't work on a build server. From my point of view, copying additional files should just be part of the build, and those files should be watched for changes, just like any other source file.
> 
> Thoughts?

**Rob Eisenberg wrote:**

> I agree with all points. Would you be willing to submit a PR to make those
> changes?

## Changes

The `input` and `output` are now relative to project folder. The setup for copying files is:

```
"bundles": [ ... ], 
"copyFiles": {
    FILE_YOU_WANT_TO_COPY_BASED_ON_PROJECT_FOLDER: DESTINATION_BASED_ON_PROJECT_FOLDER
  }
```

An example for bootstrap would be:

```
"bundles": [ ... ], 
"copyFiles": {
    "node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.woff2": "bootstrap/fonts".
    "node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.woff": "bootstrap/fonts",
    "node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.ttf": "bootstrap/fonts"
  }
```

The `copyFiles()` is now part of the `build()`, solving problem that files are currently copied only in the development process. 

The files are being watched for changes. The `gulp-changed-in-place` ensures that only changed files will be recopied.

----

I tried to follow the same strategy in the other tasks (transpile, process-markup, etc). If something is not right, please tell me.

I'll update the docs https://github.com/aurelia/framework/pull/666 when I have time.