### PR TITLE
feat(local-testing): Added esprima to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "aurelia-dependency-injection": "^1.0.0",
     "aurelia-polyfills": "^1.0.0",
+    "esprima": "^3.1.3",
     "npm": "^3.10.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Refers to #451 
With esprima declared as a dependency, an `npm link` can be used to test local changes without having to run`npm i esprima` first.
I have added it to the dependencies instead of devDependencies because it is used during runtime, even although an `npm i -g aurelia-cli` seems to magically get it from somewhere and I feel like this is safer then having some sort of 'ghost dependency' going on.