### PR TITLE
fix(bundle): hash filename after loader config added

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -179,12 +179,6 @@ exports.Bundle = class {
       let contents = concat.content;
       let bundleFileName = this.config.name;
 
-      if (buildOptions.rev) {
-        //Generate a unique hash based off of the bundle contents
-        this.hash = generateHash(concat.content);
-        bundleFileName = generateHashedPath(this.config.name, this.hash);
-      }
-
       if (loaderOptions.configTarget === this.config.name) {
         //Add to the config bundle the loader config and change the "index.html" to reference the appropriate config bundle
         concat.add(undefined, this.writeLoaderCode(platform));
@@ -193,6 +187,12 @@ exports.Bundle = class {
         if (platform.index) {
           this.setIndexFileConfigTarget(platform, path.posix.join(outputDir, bundleFileName));
         }
+      }
+
+      if (buildOptions.rev) {
+        //Generate a unique hash based off of the bundle contents
+        this.hash = generateHash(concat.content);
+        bundleFileName = generateHashedPath(this.config.name, this.hash);
       }
 
       let mapFileName = bundleFileName + '.map';


### PR DESCRIPTION
Resolves: https://github.com/aurelia/cli/issues/465
Previously, a file hash would be generated for the config target before
the loader config was added. This would cause cache busting issues
since a vendor bundle would not have any changes, and therefore have an
identical hash as previous, but other bundles would have a different
hash. The browser cached version of the vendor bundle would now
incorrectly point to a wrong file.
By moving the hashing to after the loader config is added, we now catch
the caching issue, and generate a new (correct) hash.