### PR TITLE
feat(cli-options): notify user of non-standard environment

### DIFF
--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -6,7 +6,12 @@ exports.CLIOptions = class {
   }
 
   getEnvironment() {
-    return this.getFlagValue('env') || process.env.NODE_ENV || 'dev';
+    let NODE_ENV;
+    let env = this.getFlagValue('env') || (process.env.NODE_ENV ? NODE_ENV = process.env.NODE_ENV : undefined) || 'dev';
+    if (NODE_ENV) {
+      console.log(`The selected Node Environment (${NODE_ENV}) is not a preconfigured option ('dev', 'stage', and 'prod')`)
+    }
+    return env
   }
 
   hasFlag(name, shortcut) {


### PR DESCRIPTION
Related: https://github.com/aurelia/cli/issues/488
When a user has a custom node environment (`NODE_ENV`), issues can
arise where the CLI tries to get an environment file named from the
`NODE_ENV`. This typically results in a file not found exception with
no real clues as to what went wrong.
This fix will notify the user if the `NODE_ENV` is being used, and if
it is a non-standard environment option (dev, stage, prod)