### PR TITLE
fix(watch): don't stop watch due to nonexisting files

### DIFF
--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -52,6 +52,7 @@ exports.BundledSource = class {
     let rootDir = process.cwd();
     let moduleId = this.moduleId || (this.moduleId = this.calculateModuleId(rootDir, loaderConfig));
     let that = this;
+    let modulePath = this.path;
 
     console.log(`Tracing ${moduleId}...`);
 
@@ -80,12 +81,18 @@ exports.BundledSource = class {
           if (found) {
             return found.contents;
           } else {
-            let contents = fs.readFileSync(location).toString();
+            let contents = '';
 
-            bundler.addFile({
-              path: location,
-              contents: contents
-            }, that.includedBy);
+            try {
+              contents = fs.readFileSync(location).toString();
+
+              bundler.addFile({
+                path: location,
+                contents: contents
+              }, that.includedBy);
+            } catch(e) {
+              console.log(`File not found or not accessible: ${location}. Requested by ${modulePath}`);
+            }
 
             return contents;
           }


### PR DESCRIPTION
closes https://github.com/aurelia/cli/issues/408

![image](https://cloud.githubusercontent.com/assets/2189477/23331065/37d4d69e-fb5e-11e6-9b4e-7de61f9eda85.png)

This bug is mentioned in https://github.com/aurelia/cli/issues/461 but this does not close https://github.com/aurelia/cli/issues/461. I wonder if we can somehow call [gulp-notify](https://github.com/aurelia/cli/blob/master/lib/resources/tasks/transpile.js#L22) from the CLI in cases like this.  

I'd recommend to wait for https://github.com/aurelia/cli/pull/419 to be merged so we can confirm that this bug does not reintroduce itself when traces are cached