### PR TITLE
fix(bluebird): move Bluebird config to prepended file

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.25.0
+
+### Notes for upgrading to 0.25.0
+
+We have removed the code for configuring Bluebird from `main.[js|ts]`. This code has been moved to a file that is now prepended to `vendor-bundle.js`. You will need to update the `prepend` section of your `vendor-bundle.js` configuration to start with the following two files:
+
+```json
+"prepend": [
+  "node_modules/bluebird/js/browser/bluebird.core.js",
+  "node_modules/aurelia-cli/lib/resources/scripts/configure-bluebird.js",
+```
+
+This change will remove the errors seen when running an Aurelia CLI app in Firefox, Edge, or IE.
+
 ## 0.24.0
 
 ### Features

--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -299,6 +299,7 @@ exports.ProjectTemplate = class {
           "name":"vendor-bundle.js",
           "prepend": [
             "node_modules/bluebird/js/browser/bluebird.core.js",
+            "node_modules/aurelia-cli/lib/resources/scripts/configure-bluebird.js",
             "node_modules/requirejs/require.js"
           ],
           "dependencies": [

--- a/lib/resources/scripts/configure-bluebird.js
+++ b/lib/resources/scripts/configure-bluebird.js
@@ -1,0 +1,6 @@
+//Configure Bluebird Promises.
+Promise.config({
+  warnings: {
+    wForgottenReturn: false
+  }
+});


### PR DESCRIPTION
fixes #385 

This fix hit me in a moment of inspiration. Now no more errors for configuring Bluebird after promises have been created! This is a breaking change and will require a bump to `0.25.0`.
