### PR TITLE
Ignore errors during tracing to not crash the cli

### DIFF
--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -122,6 +122,8 @@ exports.BundledSource = class {
           }, this.includedBy);
         }
       }
+    }, traceReject => {
+      // Ignore failed traces
     });
   }
 


### PR DESCRIPTION
I am not sure this is the right position within the codebase to handle syntax errors in TS files, but as far as I can see this fix works for #510 .