### PR TITLE
fix(bundle): write index file modifications after hash generation

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -180,17 +180,25 @@ exports.Bundle = class {
       let bundleFileName = this.config.name;
 
       if (loaderOptions.configTarget === this.config.name) {
-        //Add to the config bundle the loader config and change the "index.html" to reference the appropriate config bundle
+        //Add to the config bundle the loader config. Can't change index.html yet because we haven't generated hashes for all the files
         concat.add(undefined, this.writeLoaderCode(platform));
         contents = concat.content;
+
+        if (buildOptions.rev) {
+          //Generate a unique hash based off of the bundle contents
+          //Must generate hash after we write the loader config so that any other bundle changes (hash changes) can cause a new hash for the vendor file
+          this.hash = generateHash(concat.content);
+          bundleFileName = generateHashedPath(this.config.name, this.hash);
+        }
+
+        //Again, in the config setup, we're at the last bundle, and we can modify the index.html correctly now
         let outputDir = platform.baseUrl || platform.output; //If we have a baseUrl, then the files are served from there, else it's the output
         if (platform.index) {
           this.setIndexFileConfigTarget(platform, path.posix.join(outputDir, bundleFileName));
         }
-      }
-
-      if (buildOptions.rev) {
+      } else if (buildOptions.rev) {
         //Generate a unique hash based off of the bundle contents
+        //Must generate hash after we write the loader config so that any other bundle changes (hash changes) can cause a new hash for the vendor file
         this.hash = generateHash(concat.content);
         bundleFileName = generateHashedPath(this.config.name, this.hash);
       }


### PR DESCRIPTION
Resolves: https://github.com/aurelia/cli/issues/514
Ensures that the index file is modified (when using revisions) at the
correct time. Previously, it was modified before the hashes were
created, resulting in an index file that was not referencing the
correct file path. Now the index file is modified after the hash is
generated.