### PR TITLE
Fix/base64 sourcemap

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -154,9 +154,16 @@ exports.Bundle = class {
             return null;
           }
           
-          let converter = Convert.fromMapFileSource(
-            file.contents.toString(), 
-            parsedPath.dir);
+          let converter;
+
+          try {
+            converter = Convert.fromMapFileSource(
+              file.contents.toString(), 
+              parsedPath.dir);
+          } catch (e) {
+            console.log(e);
+            return null;
+          }
 
           sourceMap = converter
             ? converter.sourcemap

--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -148,6 +148,12 @@ exports.Bundle = class {
 
           let parsedPath = path.parse(file.path);
 
+          let base64SourceMap = Convert.fromSource(file.contents.toString());
+
+          if (base64SourceMap) {
+            return null;
+          }
+          
           let converter = Convert.fromMapFileSource(
             file.contents.toString(), 
             parsedPath.dir);


### PR DESCRIPTION
This will prevent the build process from crashing in two ways:

- when base64 sourcemaps are used (such as in dragula.js)
- when sourcemap files are incorrectly referenced (noticed this with interactjs)