### PR TITLE
fix(source-inclusion): detect traceDependencies from dependency resources correctly

### DIFF
--- a/lib/build/dependency-inclusion.js
+++ b/lib/build/dependency-inclusion.js
@@ -1,6 +1,5 @@
 "use strict";
 const os = require('os');
-const path = require('path');
 const SourceInclusion = require('./source-inclusion').SourceInclusion;
 
 exports.DependencyInclusion = class {
@@ -20,9 +19,8 @@ exports.DependencyInclusion = class {
     if (resources) {
       let promises = [];
 
-      resources.forEach(x => {
-        let pattern = path.join(loaderConfig.path, x);
-        let inclusion = new SourceInclusion(bundle, pattern);
+      resources.forEach(pattern => {
+        let inclusion = new SourceInclusion(bundle, pattern, loaderConfig);
         promises.push(inclusion.addAllMatchingResources(loaderConfig));
         bundle.includes.push(inclusion);
       });

--- a/lib/build/source-inclusion.js
+++ b/lib/build/source-inclusion.js
@@ -5,15 +5,18 @@ const mapStream = require('./map-stream');
 const BundledSource = require('./bundled-source').BundledSource;
 
 exports.SourceInclusion = class {
-  constructor(bundle, pattern) {
+  constructor(bundle, pattern, loaderConfig = null) {
     this.bundle = bundle;
-    this.orignalPattern = pattern;
 
     if (pattern[0] === '[' && pattern[pattern.length - 1] == ']') {
       this.traceDependencies = false;
       pattern = pattern.substring(1, pattern.length - 1);
     } else {
       this.traceDependencies = true;
+    }
+
+    if (loaderConfig) {
+        pattern = path.join(loaderConfig.path, pattern);
     }
 
     this.pattern = pattern;


### PR DESCRIPTION
https://github.com/aurelia/cli/issues/400

There are actually two issues preventing https://github.com/aurelia/cli/issues/400 from working. One is fixed by this PR, and the other one seems to be https://github.com/aurelia/cli/issues/342.

To reproduce https://github.com/aurelia/cli/issues/400:
- clone [this app](https://github.com/JeroenVinke/aurelia-cli-400)
- add the following folder to `node_modules`: [my-dependency.zip](https://github.com/aurelia/cli/files/825723/my-dependency.zip)

The setup is as follows. The aurelia-cli-400 app has a dependency called `my-dependency` which has two files (`resource1.js` and `resource2.js`) where `resource2.js` is a dependency of `resource1.js`. The `my-dependency` dependency is defined in the `vendor-bundle`:
```
          {
            "name": "my-dependency",
            "path": "../node_modules/my-dependency",
            "main": "index",
            "resources": [
                "[resource1.js]"
            ]
          }
```

What you'd expect using this setup is that `resource1.js` ends up in the `vendor-bundle` but `node_modules/my-dependency/resource2.js` does not. Without the changes in this PR both `resource1.js` and `resource2.js` are in **`app-bundle.js`**. This can be explained due to the glob pattern in SourceInclusion being invalid (as mentioned in https://github.com/aurelia/cli/issues/400), which causes neither `resource1.js` or `resource2.js` to be included in the `vendor-bundle`. Due to https://github.com/aurelia/cli/issues/342 they end up in the **app-bundle** instead.

With these changes, only `resource1.js` ends in `vendor-bundle`, which is what you'd expect. Although https://github.com/aurelia/cli/issues/342 is causing `resource2.js` to be included in `app-bundle`, so https://github.com/aurelia/cli/issues/400 is not completely "fixed" by this PR
