### PR TITLE
fix(project-template): set baseDir to '.wwwroot' for ASP.NET Core projects

### DIFF
--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -259,9 +259,11 @@ exports.ProjectTemplate = class {
     this.model.cssProcessor.source = path.posix.join(appRoot, '**/*' + this.model.cssProcessor.fileExtension);
     this.model.platform.output = this.scripts.calculateRelativePath(this.root);
     this.model.platform.index = path.posix.join(this.projectOutput.calculateRelativePath(this.root), "index.html");
+    this.model.platform.baseDir = '.';
 
     if (this.model.platform.id === 'aspnetcore') {
       this.model.platform.baseUrl = this.scripts.calculateRelativePath(this.projectOutput);
+      this.model.platform.baseDir = './wwwroot';
     }
 
     if (this.unitTests.parent) {

--- a/lib/resources/tasks/run.js
+++ b/lib/resources/tasks/run.js
@@ -27,7 +27,7 @@ let serve = gulp.series(
       port: 9000,
       logLevel: 'silent',
       server: {
-        baseDir: ['.'],
+        baseDir: [project.platform.baseDir],
         middleware: [historyApiFallback(), function(req, res, next) {
           res.setHeader('Access-Control-Allow-Origin', '*');
           next();

--- a/lib/resources/tasks/run.ts
+++ b/lib/resources/tasks/run.ts
@@ -23,7 +23,7 @@ let serve = gulp.series(
       port: 9000,
       logLevel: 'silent',
       server: {
-        baseDir: ['.'],
+        baseDir: [project.platform.baseDir],
         middleware: [historyApiFallback(), function(req, res, next) {
           res.setHeader('Access-Control-Allow-Origin', '*');
           next();


### PR DESCRIPTION
Add new `baseDir` property in aurelia.json with default value of `'.'`.
Override `baseDir` value to `'./wwwroot'` for ASP.NET Core projects.

Also allows `baseDir` to be configurable via aurelia.json instead of
having to change the hard-code value in run.js/ts.

Fixes #531