### PR TITLE
fix(build): strip .js extension from moduleIds

### DIFF
--- a/lib/build/amodro-trace/lib/loader/Loader.js
+++ b/lib/build/amodro-trace/lib/loader/Loader.js
@@ -164,6 +164,9 @@ function __exec(contents, r, d, c) {
 
     var oldNameToUrl = context.nameToUrl;
     context.nameToUrl = function (moduleName, ext, skipExt) {
+      if (moduleName.length > 3 && moduleName.slice(-3) === '.js') {
+        moduleName = moduleName.slice(0, -3);
+      }
       var url = oldNameToUrl.call(context, moduleName, ext, skipExt);
       return context.normalizePath(url);
     };


### PR DESCRIPTION
resolves https://github.com/aurelia/cli/issues/533

I'd like to discuss this with the Amodrotrace folks, but requirejs behaves differently when the .js extension is used: https://github.com/aurelia/cli/blob/d6f0ada18c4832bf0ec8296175ef1862047dce56/lib/build/amodro-trace/lib/loader/require.js#L1639

Stripping the .js extension in the override of amodrotrace seems to resolve the issue