### PR TITLE
Added default generator for creating components (view model + view)

### DIFF
--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -130,6 +130,8 @@ exports.ProjectTemplate = class {
       ProjectItem.resource('binding-behavior.json', 'generators/binding-behavior.json'),
       ProjectItem.resource('task.ext', 'generators/task.ext', this.model.transpiler),
       ProjectItem.resource('task.json', 'generators/task.json'),
+      ProjectItem.resource('component.ext', 'generators/component.ext', this.model.transpiler),
+      ProjectItem.resource('component.json', 'generators/component.json'),
       ProjectItem.resource('generator.ext', 'generators/generator.ext', this.model.transpiler),
       ProjectItem.resource('generator.json', 'generators/generator.json')
     ).addToEnvironments(

--- a/lib/resources/generators/component.js
+++ b/lib/resources/generators/component.js
@@ -1,0 +1,51 @@
+import { inject } from 'aurelia-dependency-injection';
+import { Project, ProjectItem, CLIOptions, UI } from 'aurelia-cli';
+
+var path = require('path');
+
+@inject(Project, CLIOptions, UI)
+export default class ElementGenerator {
+  constructor(project, options, ui) { 
+    this.project = project;
+    this.options = options;
+    this.ui = ui;
+  }
+
+  execute() {
+    let self = this;
+
+    return this.ui
+      .ensureAnswer(this.options.args[0], 'What would you like to call the component?')
+      .then(name => {
+
+        return self.ui.ensureAnswer(this.options.args[1], 'What sub-folder would you like to add it to?\nIf it doesn\'t exist it will be created for you.\n\nDefault folder is the source folder (src).', ".")
+          .then(subFolders => {
+
+            let fileName = this.project.makeFileName(name);
+            let className = this.project.makeClassName(name);
+
+            self.project.root.add(
+              ProjectItem.text(path.join(subFolders, fileName + ".js"), this.generateJSSource(className)),
+              ProjectItem.text(path.join(subFolders, fileName + ".html"), this.generateHTMLSource(className))
+            );
+
+            return this.project.commitChanges()
+              .then(() => this.ui.log(`Created ${name} in the '${path.join(self.project.root.name, subFolders)}' folder`));
+          });
+      });
+  }
+
+  generateJSSource(className) {
+    return `export class ${className} {     
+  constructor() {
+    this.message = 'Hello world';
+  }
+}`
+  }
+
+  generateHTMLSource(className) {
+    return `<template>
+  <h1>\${message}</h1>
+</template>`
+  }
+}

--- a/lib/resources/generators/component.json
+++ b/lib/resources/generators/component.json
@@ -1,0 +1,4 @@
+{
+  "name": "component",
+  "description": "Creates a custom component class and template (view model and view), placing them in the project source folder (or optionally in sub folders)."
+}

--- a/lib/resources/generators/component.ts
+++ b/lib/resources/generators/component.ts
@@ -1,0 +1,49 @@
+import { inject } from 'aurelia-dependency-injection';
+import { Project, ProjectItem, CLIOptions, UI } from 'aurelia-cli';
+
+var path = require('path');
+
+@inject(Project, CLIOptions, UI)
+export default class ElementGenerator {
+  constructor(private project: Project, private options: CLIOptions, private ui: UI) { }
+
+  execute() {
+    let self = this;
+
+    return this.ui
+      .ensureAnswer(this.options.args[0], 'What would you like to call the component?')
+      .then(name => {
+
+        return self.ui.ensureAnswer(this.options.args[1], 'What sub-folder would you like to add it to?\nIf it doesn\'t exist it will be created for you.\n\nDefault folder is the source folder (src).', ".")
+          .then(subFolders => {
+
+            let fileName = this.project.makeFileName(name);
+            let className = this.project.makeClassName(name);
+
+            self.project.root.add(
+              ProjectItem.text(path.join(subFolders, fileName + ".ts"), this.generateJSSource(className)),
+              ProjectItem.text(path.join(subFolders, fileName + ".html"), this.generateHTMLSource(className))
+            );
+
+            return this.project.commitChanges()
+              .then(() => this.ui.log(`Created ${name} in the '${path.join(self.project.root.name, subFolders)}' folder`));
+          });
+      });
+  }
+
+  generateJSSource(className) {
+    return `export class ${className} {    
+  message: string;
+  
+  constructor() {
+    this.message = 'Hello world';
+  }
+}`
+  }
+
+  generateHTMLSource(className) {
+    return `<template>
+  <h1>\${message}</h1>
+</template>`
+  }
+}


### PR DESCRIPTION
I really think we should have a generator for creating components (view model and views. It's the first thing I started looking for when downloading the CLI. 

I discussed this here: https://github.com/aurelia/cli/issues/547 and was asked to create a PR so here it is :)

To use this feature you will write `au generate component`

* You will then input the name of the component.
* After this you will be asked if you want to add the component to any sub folders (for example your feature folders). 

If you leave it empty you component files will be added to the src folder. If you enter a sub folder (or sub folders) that does not exist they will be created.
