### PR TITLE
Fix/dep order

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -5,6 +5,7 @@ const Convert = require('./convert-source-map');
 const fs = require('../file-system');
 const SourceInclusion = require('./source-inclusion').SourceInclusion;
 const DependencyInclusion = require('./dependency-inclusion').DependencyInclusion;
+const Utils = require('./utils');
 
 exports.Bundle = class {
   constructor(bundler, config) {
@@ -32,15 +33,18 @@ exports.Bundle = class {
   static create(bundler, config) {
     let bundle = new exports.Bundle(bundler, config);
     let dependencies = config.dependencies || [];
+    let dependenciesToBuild = dependencies
+        .filter(x => bundler.itemIncludedInBuild(x));
 
-    return Promise.all(
-      dependencies
-        .filter(x => bundler.itemIncludedInBuild(x))
-        .map(dependency => bundler.configureDependency(dependency))
-    )
-    // Add dependencies in the same order as they were entered
-    // to prevent a wrong module load order.
-    .then(descriptions => Promise.all(descriptions.map(dep => bundle.addDependency(dep))))
+    return Utils.runSequentially(
+        dependenciesToBuild,
+        dep => bundler.configureDependency(dep))
+    .then(descriptions => {
+      return Utils.runSequentially(
+        descriptions,
+        description => bundle.addDependency(description)
+      );
+    })
     .then(() => bundle);
   }
 

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -11,6 +11,23 @@ exports.generateBundleName = function(contents, fileName, rev) {
   return rev ? exports.generateHashedPath(fileName, hash) : fileName;
 };
 
+exports.runSequentially = function(tasks, cb) {
+  let index = -1;
+  let result = [];
+
+  function exec() {
+    index ++;
+
+    if (index < tasks.length) {
+      return cb(tasks[index]).then(r => result.push(r)).then(exec);
+    }
+
+    return Promise.resolve();
+  }
+
+  return exec().then(() => result);
+};
+
 exports.generateHashedPath = function(pth, hash) {
   if (arguments.length !== 2) {
     throw new Error('`path` and `hash` required');

--- a/spec/lib/build/bundle.spec.js
+++ b/spec/lib/build/bundle.spec.js
@@ -1,0 +1,259 @@
+'use strict';
+
+const BundlerMock = require('../../mocks/bundler');
+const Bundle = require('../../../lib/build/bundle').Bundle;
+
+describe('the Bundle module', () => {
+  let sut;
+
+  beforeEach(() => {
+    let bundler = new BundlerMock();
+    let config = {
+      name: 'app-bundle.js'
+    };
+    sut = new Bundle(bundler, config);
+  });
+
+  it('only prepends items that are included in the build', () => {
+    let bundler = new BundlerMock();
+    bundler.itemIncludedInBuild.and.callFake((item) => {
+      if (item === 'firstitem.js') return true;
+
+      return false;
+    });
+
+    let config = {
+      name: 'app-bundle.js',
+      prepend: [
+        'firstitem.js',
+        'seconditem.js'
+      ]
+    };
+    sut = new Bundle(bundler, config);
+
+    expect(sut.prepend.length).toBe(1);
+    expect(sut.prepend[0]).toBe('firstitem.js');
+  });
+
+  it('only appends items that are included in the build', () => {
+    let bundler = new BundlerMock();
+    bundler.itemIncludedInBuild.and.callFake((item) => {
+      if (item === 'firstitem.js') return true;
+
+      return false;
+    });
+
+    let config = {
+      name: 'app-bundle.js',
+      append: [
+        'firstitem.js',
+        'seconditem.js'
+      ]
+    };
+    sut = new Bundle(bundler, config);
+
+    expect(sut.append.length).toBe(1);
+    expect(sut.append[0]).toBe('firstitem.js');
+  });
+
+  it('strips the extension of the bundle name to get the moduleId', () => {
+    let bundler = new BundlerMock();
+
+    let config = {
+      name: 'app-bundle.js'
+    };
+    sut = new Bundle(bundler, config);
+
+    expect(sut.moduleId).toBe('app-bundle');
+  });
+
+  it('includes all sources as SourceInclusions', () => {
+    let bundler = new BundlerMock();
+
+    let config = {
+      name: 'app-bundle.js',
+      source: [
+        'src/**/*.js',
+        'othersrc/**/*.js'
+      ]
+    };
+    sut = new Bundle(bundler, config);
+
+    expect(sut.includes.length).toBe(2);
+    expect(sut.includes.find(x => x.pattern === 'src/**/*.js'));
+    expect(sut.includes.find(x => x.pattern === 'othersrc/**/*.js'));
+  });
+
+  it('source can be an object with include/exclude properties', () => {
+    let bundler = new BundlerMock();
+
+    let config = {
+      name: 'app-bundle.js',
+      source: {
+        include: ['src/**/*.js'],
+        exclude: ['src/test.js']
+      }
+    };
+    sut = new Bundle(bundler, config);
+
+    expect(sut.includes.length).toBe(1);
+    expect(sut.includes.find(x => x.pattern === 'src/**/*.js'));
+    expect(sut.excludes.length).toBe(1);
+  });
+
+  it('only includes dependencies that are included in the build', (done) => {
+    let bundler = new BundlerMock();
+    bundler.itemIncludedInBuild.and.callFake((dep) => {
+      if (dep.name && dep.name === 'my-dev-plugin') return false;
+
+      return true;
+    });
+    bundler.configureDependency.and.callFake(dep => {
+      return Promise.resolve({
+        loaderConfig: {
+          name: dep.name || dep
+        }
+      });
+    });
+
+    let config = {
+      name: 'app-bundle.js',
+      dependencies: [
+        'foo',
+        {
+          name: 'my-plugin',
+          main: 'index',
+          path: '../node_modules/my-plugin/'
+        },
+        {
+          name: 'my-dev-plugin',
+          main: 'index',
+          path: '../node_modules/my-plugin/'
+        }
+      ]
+    };
+    Bundle.create(bundler, config)
+    .then((bundle) => {
+      sut = bundle;
+      expect(sut.includes.length).toBe(2);
+      expect(sut.includes.find(x => x.description.loaderConfig.name === 'my-dev-plugin')).toBeFalsy();
+      done();
+    }).catch(e => done.fail(e));
+  });
+
+  it('transforms all includes when build is required', (done) => {
+    sut.requiresBuild = true;
+    let spy1 = jasmine.createSpy('spy1').and.returnValue(Promise.resolve());
+    let spy2 = jasmine.createSpy('spy2').and.returnValue(Promise.resolve());
+    sut.includes = [{
+      transform: spy1
+    }, {
+      transform: spy2
+    }];
+
+    sut.transform()
+    .then(() => {
+      expect(spy1).toHaveBeenCalled();
+      expect(spy2).toHaveBeenCalled();
+      done();
+    }).catch(e => done.fail(e));
+  });
+
+  it('does not transforms includes when build is not required', (done) => {
+    sut.requiresBuild = false;
+    let spy1 = jasmine.createSpy('spy1').and.returnValue(Promise.resolve());
+    let spy2 = jasmine.createSpy('spy2').and.returnValue(Promise.resolve());
+    sut.includes = [{
+      transform: spy1
+    }, {
+      transform: spy2
+    }];
+
+    sut.transform()
+    .then(() => {
+      expect(spy1).not.toHaveBeenCalled();
+      expect(spy2).not.toHaveBeenCalled();
+      done();
+    }).catch(e => done.fail(e));
+  });
+
+  it('getBundledModuleIds returns unique module ids', () => {
+    sut.includes = [{
+      getAllModuleIds: () => ['a', 'b']
+    }, {
+      getAllModuleIds: () => ['b', 'c']
+    }];
+
+    expect(sut.getBundledModuleIds()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('getBundledFiles returns all files of all includes', () => {
+    sut.includes = [{
+      getAllFiles: () => ['a.js', 'b.js']
+    }, {
+      getAllFiles: () => ['c.js']
+    }];
+
+    expect(sut.getBundledFiles()).toEqual(['a.js', 'b.js', 'c.js']);
+  });
+
+  it('add dependencies in the same order as they were entered to prevent a wrong module load order', done => {
+    let bundler = new BundlerMock();
+    bundler.configureDependency.and.callFake(dep => {
+      return Promise.resolve({
+        loaderConfig: {
+          name: dep.name || dep
+        }
+      });
+    });
+    bundler.itemIncludedInBuild.and.callFake((dep) => true);
+
+    let config = {
+      name: 'app-bundle.js',
+      dependencies: [
+        'foo',
+        {
+          name: 'my-large-plugin',
+          main: 'index',
+          path: '../node_modules/my-plugin/'
+        },
+        {
+          name: 'my-other-plugin',
+          main: 'index',
+          path: '../node_modules/my-plugin/'
+        }
+      ]
+    };
+
+    const previousAddDependency = Bundle.prototype.addDependency;
+    Bundle.prototype.addDependency = function(description) {
+      return new Promise(resolve => {
+        if (description.loaderConfig.name === 'my-large-plugin') {
+          setTimeout(() => {
+            this.includes.push({
+              description: description
+            });
+            resolve();
+          }, 200);
+        } else {
+          this.includes.push({
+            description: description
+          });
+          resolve();
+        }
+      });
+    };
+
+    Bundle.create(bundler, config)
+    .then((bundle) => {
+      expect(bundle.includes[0].description.loaderConfig.name).toBe('foo');
+      expect(bundle.includes[1].description.loaderConfig.name).toBe('my-large-plugin');
+      expect(bundle.includes[2].description.loaderConfig.name).toBe('my-other-plugin');
+      Bundle.prototype.addDependency = previousAddDependency;
+      done();
+    }).catch(e => {
+      Bundle.prototype.addDependency = previousAddDependency;
+      done.fail(e);
+    });
+  });
+});

--- a/spec/lib/build/util.spec.js
+++ b/spec/lib/build/util.spec.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const Utils = require('../../../lib/build/utils');
+
+describe('the Utils.runSequentially function', () => {
+  it('calls the callback function for all items', (d) => {
+    let items = [{ name: 'first' }, { name: 'second' }];
+    let cb = jasmine.createSpy('cb').and.returnValue(Promise.resolve());
+    Utils.runSequentially(items, cb)
+    .then(() => {
+      expect(cb.calls.count()).toBe(2);
+      expect(cb.calls.argsFor(0)[0].name).toBe('first');
+      expect(cb.calls.argsFor(1)[0].name).toBe('second');
+      d();
+    });
+  });
+
+  it('runs in sequence', (d) => {
+    let items = [{ name: 'first' }, { name: 'second' }, { name: 'third' }];
+    let cb = jasmine.createSpy('cb').and.callFake((item) => {
+      return new Promise(resolve => {
+        if (item.name === 'first' || item.name === 'second') {
+          setTimeout(() => resolve(), 200);
+        } else {
+          resolve();
+        }
+      });
+    });
+    Utils.runSequentially(items, cb)
+    .then(() => {
+      expect(cb.calls.argsFor(0)[0].name).toBe('first');
+      expect(cb.calls.argsFor(1)[0].name).toBe('second');
+      expect(cb.calls.argsFor(2)[0].name).toBe('third');
+      d();
+    });
+  });
+
+  it('handles empty items array', (done) => {
+    let items = [];
+    Utils.runSequentially(items, () => {})
+    .catch(e => {
+      done.fail(e, '', 'expected no error');
+      throw e;
+    })
+    .then(() => {
+      done();
+    });
+  });
+});

--- a/spec/mocks/bundler.js
+++ b/spec/mocks/bundler.js
@@ -1,0 +1,8 @@
+module.exports = class Bundler {
+  constructor() {
+    this.itemIncludedInBuild = jasmine.createSpy('itemIncludedInBuild');
+    this.interpretBuildOptions = jasmine.createSpy('interpretBuildOptions');
+    this.configureDependency = jasmine.createSpy('configureDependency');
+    this.addFile = jasmine.createSpy('addFile');
+  }
+};

--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,0 +1,25 @@
+module.exports = function() {
+  return {
+    files: [
+      'lib/**/*.js',
+      '!lib/resources/generators/**/*',
+      'package.json',
+      {pattern: 'spec/mocks/**/*', load: false},
+      {pattern: 'spec/helpers/polyfills.js', load: false}
+    ],
+
+    tests: [
+      'spec/**/*[Ss]pec.js'
+    ],
+
+    env: {
+      type: 'node'
+    },
+
+    bootstrap: function(wallaby) {
+      require('aurelia-polyfills');
+    },
+
+    testFramework: 'jasmine'
+  };
+};


### PR DESCRIPTION
Adds some initial test coverage of the Bundle class., including two (initially failing) tests that causes https://github.com/aurelia/cli/issues/378. 

And also includes the fix for https://github.com/aurelia/cli/issues/378 by making sure that both `bundler.configureDependency` as well as `bundle.addDependency` are run in sequence. When this is not the case, then either the dependencies sometimes end up in a different order, or the paths in the requirejs config in the vendor-bundle is sometimes in a different order. Both result in a different hash value for the bundle