### PR TITLE
find location of packages outside of node_modules, support packages without package.json

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -94,7 +94,7 @@ exports.Bundle = class {
   }
 
   getDependencyLocations() {
-    return this.includes.filter(inclusion => inclusion.description)
+    return this.includes.filter(inclusion => inclusion.description && inclusion.description.location)
       .map(inclusion => {
         let normalizedLocation = path.posix.normalize(inclusion.description.location).replace(/\\/g, '\/');
         return {

--- a/lib/build/package-analyzer.js
+++ b/lib/build/package-analyzer.js
@@ -34,9 +34,13 @@ exports.PackageAnalyzer = class {
 
 function loadPackageMetadata(project, description) {
   return setLocation(project, description)
-    .then(() => fs.readFile(description.metadataLocation))
-    .then(data => {
-      description.metadata = JSON.parse(data.toString());
+    .then(() => {
+      if (description.metadataLocation) {
+        return fs.readFile(description.metadataLocation)
+        .then(data => {
+          description.metadata = JSON.parse(data.toString());
+        });
+      }
     })
     .catch(e => {
       console.log(`Unable to load package metadata (package.json) of ${description.name}:`);
@@ -49,16 +53,20 @@ function determineLoaderConfig(project, description) {
   let location = path.resolve(description.location);
   let sourcePath;
 
-  if (metadata.jspm) {
-    let jspm = metadata.jspm;
+  if (metadata) {
+    if (metadata.jspm) {
+      let jspm = metadata.jspm;
 
-    if (jspm.directories && jspm.directories.dist) {
-      sourcePath = path.join(location, jspm.directories.dist, jspm.main);
+      if (jspm.directories && jspm.directories.dist) {
+        sourcePath = path.join(location, jspm.directories.dist, jspm.main);
+      } else {
+        sourcePath = path.join(location, metadata.main);
+      }
     } else {
       sourcePath = path.join(location, metadata.main);
     }
   } else {
-    sourcePath = path.join(location, metadata.main);
+    sourcePath = path.join(location, 'index');
   }
 
   sourcePath = path.relative(path.resolve(project.paths.root), sourcePath);
@@ -75,7 +83,8 @@ function setLocation(project, description) {
     return getPackageFolder(project, description)
       .then(packageFolder => {
         description.location = packageFolder;
-        description.metadataLocation = path.join(description.location, 'package.json');
+
+        return tryFindMetadata(project, description);
       });
   case 'custom':
     if (!description.loaderConfig || !description.loaderConfig.packageRoot) {
@@ -85,12 +94,17 @@ function setLocation(project, description) {
     }
 
     description.location = path.resolve(project.paths.root, description.loaderConfig.packageRoot);
-    description.metadataLocation = path.join(description.location, 'package.json');
 
-    return Promise.resolve();
+    return tryFindMetadata(project, description);
   default:
     return Promise.reject(`The package source "${description.source}" is not supported.`);
   }
+}
+
+function tryFindMetadata(project, description) {
+  return fs.stat(path.join(description.location, 'package.json'))
+    .then(() => description.metadataLocation = path.join(description.location, 'package.json'))
+    .catch(() => {});
 }
 
 function getPackageFolder(project, description) {

--- a/lib/build/package-analyzer.js
+++ b/lib/build/package-analyzer.js
@@ -28,7 +28,7 @@ exports.PackageAnalyzer = class {
     description.source = 'custom';
     description.loaderConfig = loaderConfig;
 
-    return Promise.resolve(description);
+    return loadPackageMetadata(this.project, description).then(() => description);
   }
 };
 
@@ -37,6 +37,10 @@ function loadPackageMetadata(project, description) {
     .then(() => fs.readFile(description.metadataLocation))
     .then(data => {
       description.metadata = JSON.parse(data.toString());
+    })
+    .catch(e => {
+      console.log(`Unable to load package metadata (package.json) of ${description.name}:`);
+      console.log(e);
     });
 }
 
@@ -73,8 +77,19 @@ function setLocation(project, description) {
         description.location = packageFolder;
         description.metadataLocation = path.join(description.location, 'package.json');
       });
+  case 'custom':
+    if (!description.loaderConfig || !description.loaderConfig.packageRoot) {
+      return Promise.reject(`Error: packageRoot property not defined for the "${description.name}" package. It is recommended to ` +
+      'define the packageRoot for packages outside the node_modules folder, so that the files end up in' +
+      'the correct bundle');
+    }
+
+    description.location = path.resolve(project.paths.root, description.loaderConfig.packageRoot);
+    description.metadataLocation = path.join(description.location, 'package.json');
+
+    return Promise.resolve();
   default:
-    throw new Error(`The package source "${description.source}" is not supported.`);
+    return Promise.reject(`The package source "${description.source}" is not supported.`);
   }
 }
 

--- a/spec/lib/build/package-analyzer.spec.js
+++ b/spec/lib/build/package-analyzer.spec.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const path = require('path');
+const PackageAnalyzer = require('../../../lib/build/package-analyzer').PackageAnalyzer;
+
+describe('The PackageAnalyzer', () => {
+  let mockfs;
+  let project;
+  let sut;
+
+  beforeEach(() => {
+    mockfs = require('mock-fs');
+
+    project = {
+      paths: {
+        root: './src/'
+      }
+    };
+
+    sut = new PackageAnalyzer(project);
+
+    const fsConfig = {};
+    mockfs(fsConfig);
+  });
+
+  afterEach(() => {
+    mockfs.restore();
+  });
+
+  it('sets source to npm when node_modules is found in the path', done => {
+    // setup mock package.json
+    const fsConfig = {};
+    fsConfig[path.join('node_modules/my-package', 'package.json')] = '{ }';
+    mockfs(fsConfig);
+
+    let loaderConfig = {
+      name: 'my-package',
+      path: '../node_modules/my-package'
+    };
+
+    sut.reverseEngineer(loaderConfig)
+    .then(description => {
+      expect(description.source).toBe('npm');
+      expect(description.loaderConfig).toBe(loaderConfig);
+      done();
+    })
+    .catch(e => done.fail(e));
+  });
+
+  it('sets source to custom when node_modules is not found in the path', done => {
+    // setup mock package.json
+    const fsConfig = {};
+    fsConfig[path.join('some-folder/my-package', 'package.json')] = '{ }';
+    mockfs(fsConfig);
+
+    let loaderConfig = {
+      name: 'my-package',
+      path: '../some-folder/my-package',
+      packageRoot: '../some-folder/my-package'
+    };
+
+    sut.reverseEngineer(loaderConfig)
+    .then(description => {
+      expect(description.source).toBe('custom');
+      expect(description.loaderConfig).toBe(loaderConfig);
+      done();
+    })
+    .catch(e => done.fail(e));
+  });
+
+  it('creates description when there is no package.json', done => {
+    const fsConfig = {};
+    mockfs(fsConfig);
+
+    let loaderConfig = {
+      name: 'my-package',
+      path: '../some-folder/my-package',
+      packageRoot: '../some-folder/my-package'
+    };
+
+    sut.reverseEngineer(loaderConfig)
+    .then(description => {
+      expect(description.source).toBe('custom');
+      expect(description.loaderConfig).toBe(loaderConfig);
+      done();
+    })
+    .catch(e => done.fail(e));
+  });
+
+  it('reads package.json as package metadata', done => {
+    // setup mock package.json
+    const fsConfig = {};
+    fsConfig[path.join('some-folder/my-package', 'package.json')] = '{ "name": "my-package" }';
+    mockfs(fsConfig);
+
+    let loaderConfig = {
+      name: 'my-package',
+      path: '../some-folder/my-package',
+      packageRoot: '../some-folder/my-package'
+    };
+
+    sut.reverseEngineer(loaderConfig)
+    .then(description => {
+      expect(description.metadata.name).toBe('my-package');
+      done();
+    })
+    .catch(e => done.fail(e));
+  });
+
+  it('analyze() reads package.json as package metadata', done => {
+    // setup mock package.json
+    // setup mock package.json
+    const fsConfig = {};
+    fsConfig[path.join('node_modules/my-package', 'package.json')] = '{ "name": "my-package", "main": "index.js" }';
+    fsConfig[project.paths.root] = {};
+    mockfs(fsConfig);
+
+    sut.analyze('my-package')
+    .then(description => {
+      expect(description.metadata.name).toBe('my-package');
+      done();
+    })
+    .catch(e => done.fail(e));
+  });
+
+  it('analyze() determines loaderConfig', done => {
+    // setup mock package.json
+    const fsConfig = {};
+    fsConfig[path.join('node_modules/my-package', 'package.json')] = '{ "name": "my-package", "main": "index.js" }';
+    fsConfig[project.paths.root] = {};
+    mockfs(fsConfig);
+
+    sut.analyze('my-package')
+    .then(description => {
+      expect(description.loaderConfig.name).toBe('my-package');
+      expect(description.loaderConfig.path).toBe('..\\node_modules\\my-package\\index');
+      done();
+    })
+    .catch(e => done.fail(e));
+  });
+
+  it('analyze() uses jspm.directories.dist and jspm.main path if available', done => {
+    // setup mock package.json
+    const fsConfig = {};
+    let json = '{ "name": "my-package", "main": "index.js", "jspm": { "directories": { "dist": "foobar" }, "main": "my-main.js" } }';
+    fsConfig[path.join('node_modules/my-package', 'package.json')] = json;
+    fsConfig[project.paths.root] = {};
+    mockfs(fsConfig);
+
+    sut.analyze('my-package')
+    .then(description => {
+      expect(description.loaderConfig.name).toBe('my-package');
+      expect(description.loaderConfig.path).toBe('..\\node_modules\\my-package\\foobar\\my-main');
+      done();
+    })
+    .catch(e => done.fail(e));
+  });
+
+  it('analyze() works when there is no package.json. Uses index.js as the main file', done => {
+    // setup mock package.json
+    const fsConfig = {};
+    fsConfig[path.join('node_modules/my-package')] = {};
+    fsConfig[project.paths.root] = {};
+    mockfs(fsConfig);
+
+    sut.analyze('my-package')
+    .then(description => {
+      expect(description.loaderConfig.name).toBe('my-package');
+      expect(description.loaderConfig.path).toBe('..\\node_modules\\my-package\\index');
+      done();
+    })
+    .catch(e => done.fail(e));
+  });
+});


### PR DESCRIPTION
fixes https://github.com/aurelia/cli/issues/567

@AStoker i'd like to hear your thoughts on the following. We need the root folder of a package (kept in `description.location` and looks something like `c:/development/my-app/node_modules/my-plugin/`) for two things:

1. to look for (and read) the package.json of the package (which is [used](https://github.com/aurelia/cli/blob/master/lib/build/package-analyzer.js#L48) to determine the loader configuration)
2. to determine [what bundle](https://github.com/aurelia/cli/issues/342#issuecomment-286362197) to put files in. In other words, to prevent files from ending up in `app-bundle.js` when they should have ended up in `vendor-bundle.js` (or other)

Currently the root folder of packages inside the node_modules folder is determined as follows. You resolve the `path` of the package (as defined in aurelia.json) which could be `c:/development/my-app/node_modules/my-plugin/dist/` and traverse up the folder tree until you hit the `node_modules`. The path until the first segment after `node_modules` is then used as the package root folder (`c:/development/my-app/node_modules/my-plugin`).

When you keep packages outside the node_modules folder, this trick does not work because there is no standard folder name like `node_modules` to look for in the path. So as far as I know there is no reliable way of knowing what the root folder of the package is when the package is not inside the `node_modules` folder. 

So this PR enforces that if you define dependencies outside the `node_modules` folder, that you must define a `packageRoot` :

```
          {
            "name": "jquery",
            "path": "../external_modules/jquery/dist",
            "packageRoot": "../external_modules/jquery",
            "main": "jquery.min"
          }
```

