### PR TITLE
Fix/paths aureliajson

### DIFF
--- a/lib/build/bundler.js
+++ b/lib/build/bundler.js
@@ -25,7 +25,7 @@ exports.Bundler = class {
 
     this.loaderConfig = {
       baseUrl: project.paths.root,
-      paths: {},
+      paths: ensurePathsRelativelyFromRoot(project.paths || {}),
       packages: [],
       stubModules: [],
       shim: {}
@@ -233,4 +233,27 @@ function subsume(bundles, item) {
 
 function normalizeKey(p) {
   return path.normalize(p);
+}
+
+function ensurePathsRelativelyFromRoot(p) {
+  let keys = Object.keys(p);
+  let original = JSON.stringify(p, null, 2);
+  let warn = false;
+
+  for (let i = 0; i < keys.length; i++) {
+    let key = keys[i];
+    if (key !== 'root' && p[key].indexOf(p.root + '/') === 0) {
+      warn = true;
+      p[key] = p[key].slice(p.root.length + 1);
+    }
+  }
+
+  if (warn) {
+    console.log('Warning: paths in the "paths" object in aurelia.json must be relative from the root path. Change ');
+    console.log(original);
+    console.log('to: ');
+    console.log(JSON.stringify(p, null, 2));
+  }
+
+  return p;
 }

--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -248,11 +248,11 @@ exports.ProjectTemplate = class {
 
     this.model.paths = Object.assign(this.model.paths, {
       root: appRoot,
-      resources: this.resources.calculateRelativePath(this.root),
-      elements: this.elements.calculateRelativePath(this.root),
-      attributes: this.attributes.calculateRelativePath(this.root),
-      valueConverters: this.valueConverters.calculateRelativePath(this.root),
-      bindingBehaviors: this.bindingBehaviors.calculateRelativePath(this.root)
+      resources: this.resources.calculateRelativePath(this.src),
+      elements: this.elements.calculateRelativePath(this.src),
+      attributes: this.attributes.calculateRelativePath(this.src),
+      valueConverters: this.valueConverters.calculateRelativePath(this.src),
+      bindingBehaviors: this.bindingBehaviors.calculateRelativePath(this.src)
     });
 
     this.model.transpiler.source = path.posix.join(appRoot, '**/*' + this.model.transpiler.fileExtension);

--- a/spec/lib/build/bundler.spec.js
+++ b/spec/lib/build/bundler.spec.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const Bundler = require('../../../lib/build/bundler').Bundler;
+const PackageAnalyzer = require('../../mocks/package-analyzer');
+const CLIOptionsMock = require('../../mocks/cli-options');
+
+describe('the Bundler module', () => {
+  let analyzer;
+  let cliOptionsMock;
+
+  beforeEach(() => {
+    analyzer = new PackageAnalyzer();
+    cliOptionsMock = new CLIOptionsMock();
+    cliOptionsMock.attach();
+  });
+
+  it('uses paths.root from aurelia.json in the loaderConfig as baseUrl', () => {
+    let project = {
+      paths: {
+        root: 'src'
+      },
+      build: { loader: {} }
+    };
+    let bundler = new Bundler(project, analyzer);
+    expect(bundler.loaderConfig.baseUrl).toBe('src');
+  });
+
+  it('takes paths from aurelia.json and uses it in the loaderConfig', () => {
+    let project = {
+      paths: {
+        root: 'src',
+        foo: 'bar'
+      },
+      build: { loader: {} }
+    };
+    let bundler = new Bundler(project, analyzer);
+    expect(bundler.loaderConfig.paths.root).toBe('src');
+    expect(bundler.loaderConfig.paths.foo).toBe('bar');
+  });
+
+  it('ensures that paths in aurelia.json are relative from the root path', () => {
+    let project = {
+      paths: {
+        root: 'src',
+        foo: 'src/bar'
+      },
+      build: { loader: {} }
+    };
+    let bundler = new Bundler(project, analyzer);
+    expect(bundler.loaderConfig.paths.foo).toBe('bar');
+  });
+
+  afterEach(() => {
+    cliOptionsMock.detach();
+  });
+});

--- a/spec/mocks/bundler.js
+++ b/spec/mocks/bundler.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = class Bundler {
   constructor() {
     this.itemIncludedInBuild = jasmine.createSpy('itemIncludedInBuild');

--- a/spec/mocks/cli-options.js
+++ b/spec/mocks/cli-options.js
@@ -1,0 +1,19 @@
+'use strict';
+
+let OriginalCLIOptions = require('../../lib/cli-options').CLIOptions;
+
+module.exports = class CLIOptionsMock {
+
+  constructor() {
+    this.originalFns = {};
+  }
+
+  attach() {
+    this.originalFns.getEnvironment = OriginalCLIOptions.prototype.getEnvironment;
+    OriginalCLIOptions.getEnvironment = jasmine.createSpy('getEnvironment');
+  }
+
+  detach() {
+    OriginalCLIOptions.getEnvironment = this.originalFns.getEnvironment;
+  }
+};

--- a/spec/mocks/package-analyzer.js
+++ b/spec/mocks/package-analyzer.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = class PackageAnalyzer {
+  constructor() {
+  }
+};


### PR DESCRIPTION
closes #352 

Previously only `root` property of the `paths` object in aurelia.json was used by the CLI. The others were ignored. This PR fixes that

unfortunately, projects that were generated previously have incorrect paths. They have:

```
  "paths": {
    "root": "src",
    "resources": "src/resources",
    "elements": "src/resources/elements",
    "attributes": "src/resources/attributes",
    "valueConverters": "src/resources/value-converters",
    "bindingBehaviors": "src/resources/binding-behaviors"
  },
```

while all paths except for `root` should be relatively from the root path. 

So I have made sure that the CLI gracefully recovers from this situation and shows a warning message:

![image](https://cloud.githubusercontent.com/assets/2189477/24581993/51d630ae-1726-11e7-9456-dae015441140.png)

We can remove this graceful recovery logic after a while