### PR TITLE
Feat/support static json files

### DIFF
--- a/lib/build/amodro-trace/index.js
+++ b/lib/build/amodro-trace/index.js
@@ -81,7 +81,7 @@ module.exports = function trace(options, loaderConfig) {
     };
     options.logger = logger;
 
-    var loader = new Loader(options);
+    var loader = new Loader(options, loaderConfig);
 
     if (loaderConfig) {
       loader.getContext().configure(loaderConfig);

--- a/lib/build/amodro-trace/lib/loader/Loader.js
+++ b/lib/build/amodro-trace/lib/loader/Loader.js
@@ -38,6 +38,10 @@ function normalizeModuleId(moduleId) {
     moduleId = moduleId.split('!')[1];
   }
 
+  if (moduleId.length > 3 && moduleId.slice(-3) === '.js') {
+    moduleId = moduleId.slice(0, -3);
+  }
+
   return moduleId;
 }
 

--- a/lib/build/amodro-trace/lib/loader/Loader.js
+++ b/lib/build/amodro-trace/lib/loader/Loader.js
@@ -168,8 +168,9 @@ function __exec(contents, r, d, c) {
       return context.normalizePath(url);
     };
 
-    context._setToolOptions = function(options) {
+    context._setToolOptions = function(options, loaderConfig) {
       context.config._options = options;
+      context.config._loaderConfig = loaderConfig;
 
       // Caching function for performance.
       var contextRead = defaultRead.bind(null, context);
@@ -420,7 +421,7 @@ function __exec(contents, r, d, c) {
                   has: context.config.has,
                   findNestedDependencies:
                                 context.config._options.findNestedDependencies
-                });
+                }, context.config._loaderConfig, context);
               }
             } catch (e2) {
               throw new Error('Parse error using esprima ' +
@@ -648,7 +649,7 @@ function __exec(contents, r, d, c) {
 
   var idCounter = 0;
 
-  function Loader(options) {
+  function Loader(options, loaderConfig) {
     var id;
     while (!id) {
       id = 'context' + (idCounter++);
@@ -670,7 +671,7 @@ function __exec(contents, r, d, c) {
     });
 
     var context = this.getContext();
-    context._setToolOptions(options || {});
+    context._setToolOptions(options || {}, loaderConfig || {});
 
     if (options.traced) {
       options.traced.forEach(function(traceItem) {

--- a/lib/build/amodro-trace/lib/loader/Loader.js
+++ b/lib/build/amodro-trace/lib/loader/Loader.js
@@ -33,6 +33,14 @@ function __exec(contents, r, d, c) {
   eval(contents);
 }
 
+function normalizeModuleId(moduleId) {
+  if (parse.hasPrefix(moduleId)) {
+    moduleId = moduleId.split('!')[1];
+  }
+
+  return moduleId;
+}
+
 // Patch requirejs to work for build purposes.
 (function() {
   var hasProp = lang.hasProp,
@@ -164,6 +172,8 @@ function __exec(contents, r, d, c) {
 
     var oldNameToUrl = context.nameToUrl;
     context.nameToUrl = function (moduleName, ext, skipExt) {
+      moduleName = normalizeModuleId(moduleName);
+
       var url = oldNameToUrl.call(context, moduleName, ext, skipExt);
       return context.normalizePath(url);
     };

--- a/lib/build/amodro-trace/lib/loader/Loader.js
+++ b/lib/build/amodro-trace/lib/loader/Loader.js
@@ -7,6 +7,7 @@
 var fs = require('fs'),
     lang = require('../lang'),
     parse = require('../parse'),
+    normalize = require('../normalize'),
     path = require('path'),
     exists = fs.existsSync || path.existsSync,
     nodeRequire = require;
@@ -31,18 +32,6 @@ function __exec(contents, r, d, c) {
   };
 
   eval(contents);
-}
-
-function normalizeModuleId(moduleId) {
-  if (parse.hasPrefix(moduleId)) {
-    moduleId = moduleId.split('!')[1];
-  }
-
-  if (moduleId.length > 3 && moduleId.slice(-3) === '.js') {
-    moduleId = moduleId.slice(0, -3);
-  }
-
-  return moduleId;
 }
 
 // Patch requirejs to work for build purposes.
@@ -176,7 +165,7 @@ function normalizeModuleId(moduleId) {
 
     var oldNameToUrl = context.nameToUrl;
     context.nameToUrl = function (moduleName, ext, skipExt) {
-      moduleName = normalizeModuleId(moduleName);
+      moduleName = normalize.normalizeModuleId(moduleName);
 
       var url = oldNameToUrl.call(context, moduleName, ext, skipExt);
       return context.normalizePath(url);

--- a/lib/build/amodro-trace/lib/normalize.js
+++ b/lib/build/amodro-trace/lib/normalize.js
@@ -1,0 +1,19 @@
+var parse = require('./parse');
+
+module.exports = {
+  normalizeModuleId: function (moduleId) {
+    if (parse.hasPrefix(moduleId)) {
+      moduleId = moduleId.split('!')[1];
+    }
+
+    if (moduleId.slice(-1) === '/') {
+      moduleId = moduleId.slice(0, -1);
+    }
+
+    if (moduleId.length > 3 && moduleId.slice(-3) === '.js') {
+      moduleId = moduleId.slice(0, -3);
+    }
+
+    return moduleId;
+  }
+};

--- a/lib/build/amodro-trace/lib/parse.js
+++ b/lib/build/amodro-trace/lib/parse.js
@@ -122,7 +122,7 @@ define(['esprima', './lang'], function (esprima, lang) {
      * @returns {String} JS source string or null, if no require or
      * define/require.def calls are found.
      */
-    function parse(moduleName, fileName, fileContents, options) {
+    function parse(moduleName, fileName, fileContents, options, loaderConfig, context) {
         options = options || {};
 
         //Set up source input
@@ -167,6 +167,8 @@ define(['esprima', './lang'], function (esprima, lang) {
         }
 
         if (moduleDeps.length || moduleList.length) {
+            parse.registerPluginPaths(moduleDeps, loaderConfig, moduleName, context);
+
             for (i = 0; i < moduleList.length; i++) {
                 moduleCall = moduleList[i];
                 if (result) {
@@ -1071,10 +1073,86 @@ define(['esprima', './lang'], function (esprima, lang) {
                 }
 
             }
-        }
+        };
 
         return result;
     };
+
+    /**
+     * Adds map entries for paths that have specific extensions (currently only .json) to two requirejs configs:
+     * - the requirejs config passed to amodrotrace (so that the same map can be sent to the browser)
+     * - the requirejs config of the current context of amodrotrace
+     * 
+     * Example: require("./my-file.json") of the "my-package/index" module will result in:
+     * {
+     *  map: {
+     *    "*": {
+     *      "my-package/my-file.json": "json!my-package/my-file.json"
+     *    }    
+     *  }
+     * }
+     */
+    parse.registerPluginPaths = function (deps, loaderConfig, parentModule, ctx) {
+        for(var i = 0; i < deps.length; i++) {
+            if (parse.hasPrefix(deps[i])) 
+                continue;
+
+            var extension = parse.getExtension(deps[i]);
+            var pluginExtensions = ['json'];
+
+            if (extension && pluginExtensions.indexOf(extension) > -1) {
+                var depMap = ctx.makeModuleMap(deps[i],
+                                ctx.makeModuleMap(parentModule),
+                                null,
+                                true);
+
+                var resolvedName = depMap.name;
+                var nameWithPluginPrefix = extension + '!' + depMap.name;
+
+                // add map to loader config that's passed to amodrotrace
+                if (!loaderConfig.map) loaderConfig.map = {};
+                if (!loaderConfig.map['*']) loaderConfig.map['*'] = {};
+                loaderConfig.map['*'][resolvedName] = nameWithPluginPrefix;
+
+                // configure RequireJS with the map
+                var config = { 
+                    map: { 
+                        "*": {}
+                    }
+                };
+
+                config.map['*'][resolvedName] = nameWithPluginPrefix;
+
+                ctx.configure(config);
+            }
+        }
+    };
+
+    /**
+     * Returns the extension of a file
+     */
+    parse.getExtension = function (path) {
+        var extensionRegex = /(?:\.)([0-9a-z]+)$/;
+        var extMatch = path.match(extensionRegex);
+
+        if (extMatch && extMatch.length > 1) {
+            return extMatch[1];
+        }
+
+        return null;
+    };
+
+    /**
+     * Returns whether or not the path has a plugin prefix
+     * E.g. json!some-file.json -> true
+     * some-file.json -> false
+     */
+    parse.hasPrefix = function (path) {
+        var index = path ? path.indexOf('!') : -1;
+
+        return index > -1;
+    };
+
 
     return parse;
 });

--- a/lib/build/bundler.js
+++ b/lib/build/bundler.js
@@ -26,6 +26,7 @@ exports.Bundler = class {
     this.loaderConfig = {
       baseUrl: project.paths.root,
       paths: ensurePathsRelativelyFromRoot(project.paths || {}),
+      map: project.map || {},
       packages: [],
       stubModules: [],
       shim: {}

--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -25,7 +25,8 @@ exports.ProjectTemplate = class {
     };
 
     this.model = Object.assign({}, model, {
-      paths: {}
+      paths: {},
+      map: {}
     });
 
     this.postInstallProcesses = [];
@@ -55,6 +56,15 @@ exports.ProjectTemplate = class {
     this.tasks = ProjectItem.directory('tasks');
     this.generators = ProjectItem.directory('generators');
     this.environments = ProjectItem.directory('environments');
+
+    this.nodeModules = ProjectItem.directory('../node_modules');
+
+    this.jsonPlugin = ProjectItem.file('json.js');
+    this.nodeModules.add(
+      ProjectItem.directory('../node_modules/requirejs-json').add(
+        this.jsonPlugin
+      )
+    );
 
     this.projectFolder = ProjectItem.directory('aurelia_project').add(
       this.tasks,
@@ -143,7 +153,8 @@ exports.ProjectTemplate = class {
       'aurelia-animator-css',
       'bluebird',
       'requirejs',
-      'text'
+      'text',
+      'requirejs-json'
     ).addToDevDependencies(
       'aurelia-cli',
       'aurelia-testing',
@@ -252,7 +263,8 @@ exports.ProjectTemplate = class {
       elements: this.elements.calculateRelativePath(this.src),
       attributes: this.attributes.calculateRelativePath(this.src),
       valueConverters: this.valueConverters.calculateRelativePath(this.src),
-      bindingBehaviors: this.bindingBehaviors.calculateRelativePath(this.src)
+      bindingBehaviors: this.bindingBehaviors.calculateRelativePath(this.src),
+      json: this.jsonPlugin.calculateRelativePath(this.src).replace('.js', '')
     });
 
     this.model.transpiler.source = path.posix.join(appRoot, '**/*' + this.model.transpiler.fileExtension);
@@ -283,7 +295,8 @@ exports.ProjectTemplate = class {
         'configTarget': 'vendor-bundle.js',
         'includeBundleMetadataInConfig': 'auto',
         'plugins': [
-          { 'name': 'text', 'extensions': ['.html', '.css'], 'stub': true }
+          { 'name': 'text', 'extensions': ['.html', '.css'], 'stub': true },
+          { 'name': 'json', 'extensions': ['.json'], 'stub': true }
         ]
       },
       'options': {

--- a/lib/commands/new/transpilers/typescript.js
+++ b/lib/commands/new/transpilers/typescript.js
@@ -9,7 +9,9 @@ module.exports = function(project) {
   project.addToContent(
     ProjectItem.resource('tslint.json', 'content/tslint.json'),
     ProjectItem.resource('tsconfig.json', 'content/tsconfig.json'),
-    ProjectItem.directory('custom_typings')
+    ProjectItem.directory('custom_typings').add(
+      ProjectItem.resource('custom_typings.d.ts', 'content/custom_typings.d.ts')
+    )
   ).addToTasks(
     ProjectItem.resource('transpile.ts', 'tasks/transpile.ts')
     ).addToDevDependencies(

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -45,6 +45,7 @@ let versionMap = {
   'karma-typescript-preprocessor': '^0.2.1',
   'minimatch': '^3.0.2',
   'requirejs': '^2.3.2',
+  'requirejs-json': '^0.0.3',
   'text': 'github:requirejs/text#latest',
   'through2': '^2.0.1',
   'tslint': '^3.11.0',

--- a/lib/resources/content/custom_typings.d.ts
+++ b/lib/resources/content/custom_typings.d.ts
@@ -1,0 +1,9 @@
+declare module "text!*" {
+    const value: any;
+    export default value;
+}
+
+declare module "json!*" {
+    const value: any;
+    export default value;
+}

--- a/spec/lib/build/amodro-trace/lib/normalize.spec.js
+++ b/spec/lib/build/amodro-trace/lib/normalize.spec.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Normalize = require('../../../../../lib/build/amodro-trace/lib/normalize');
+
+describe('the amodro-trace normalize module', () => {
+  describe('the module id normalizer', () => {
+    it('strips slash from the end of a module id', () => {
+      expect(Normalize.normalizeModuleId('some-module-id/')).toBe('some-module-id');
+    });
+
+    it('strips .js from the end of a module id', () => {
+      expect(Normalize.normalizeModuleId('some-module-id.js')).toBe('some-module-id');
+    });
+
+    it('strips plugin loader prefix', () => {
+      expect(Normalize.normalizeModuleId('text!some-module-id')).toBe('some-module-id');
+    });
+
+    it('returns moduleid if no normalization takes place', () => {
+      expect(Normalize.normalizeModuleId('some-module-id')).toBe('some-module-id');
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/aurelia/cli/issues/588

With the changes in this PR, if a `map` property is present in aurelia.json, it will be used in the requirejs config. That should allow users to have more control over the configuration of the loader

I believe that any moduleid that has an extension (except .js) should be loaded through a requirejs plugin. For example, `require('./some-file.json')` needs to be loaded through the JSON plugin, and `require('./some-file.css')` needs to be loaded through the text plugin. Quite a few packages `require` json files, so the CLI should be able to deal with those.

During the tracing step, whenever a moduleid is encountered that has an extension but no plugin loader prefix (e.g. `require('./my-file.json`), a `map` entry is added to the requirejs config. One example:

When the `my-package` dependency does an import of `require('my-file.json`)`, this `map` entry is added:
```
map: {
  '*': {
    'my-package/my-file.json': 'json!my-package/my-file.json'
  }
}
```

It uses the extension as the loader plugin. So if a package you use imports a json file, you need to make sure that the loader is set up to load json files. This resolves https://github.com/aurelia/cli/issues/588

Since quite a few packages import json files, I think we should make JSON a first class citizen by adding the json plugin to new projects by default. So i've added those changes to this PR, and we can decide whether to go through with that or not

I'd like to do a bit more testing before we merge this,