### PR TITLE
create a configuration node for BrowserSync at task/run.js

### DIFF
--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -28,6 +28,8 @@ exports.ProjectTemplate = class {
       paths: {}
     });
 
+    this.model.serve = this.createServeConfig();
+
     this.postInstallProcesses = [];
 
     this.root = options.hasFlag('here')
@@ -62,6 +64,13 @@ exports.ProjectTemplate = class {
       this.environments,
       ProjectItem.jsonObject('aurelia.json', this.model)
     );
+  }
+
+  createServeConfig(){
+    return {
+      localPort:9000,
+      logLevel:'silent'
+    };
   }
 
   get name() {

--- a/lib/resources/tasks/run.js
+++ b/lib/resources/tasks/run.js
@@ -24,8 +24,8 @@ let serve = gulp.series(
     browserSync({
       online: false,
       open: false,
-      port: 9000,
-      logLevel: 'silent',
+      port: project.serve.localPort,
+      logLevel: project.serve.logLevel,
       server: {
         baseDir: [project.platform.baseDir],
         middleware: [historyApiFallback(), function(req, res, next) {

--- a/lib/resources/tasks/run.ts
+++ b/lib/resources/tasks/run.ts
@@ -20,8 +20,8 @@ let serve = gulp.series(
     browserSync({
       online: false,
       open: false,
-      port: 9000,
-      logLevel: 'silent',
+      port: project.serve.localPort,
+      logLevel: project.serve.logLevel,
       server: {
         baseDir: [project.platform.baseDir],
         middleware: [historyApiFallback(), function(req, res, next) {


### PR DESCRIPTION
Added a node in aurelia.json for BrowserSync Configuration.
`
  "serve": {
    "localPort": 9000,
    "logLevel": "silent"
  },
`
