### PR TITLE
feat(build): allow minify options to be supplied

### DIFF
--- a/lib/build/build-options.js
+++ b/lib/build/build-options.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const CLIOptions = require('../cli-options').CLIOptions;
+
+exports.BuildOptions = class {
+  constructor(options, defaultOptions, environment) {
+    this.options = Object.assign({}, defaultOptions, options);
+    this.environment = environment || CLIOptions.getEnvironment();
+  }
+
+  getAllOptions() {
+    return this.options;
+  }
+
+  getValue(propPath) {
+    let split = propPath.split('.');
+    let cur = this.options;
+
+    for (let i = 0; i < split.length; i++) {
+      if (!cur) {
+        return undefined;
+      }
+
+      cur = cur[split[i]];
+    }
+
+    return cur;
+  }
+
+  isApplicable(propPath) {
+    let value = this.getValue(propPath);
+
+    if (!value) {
+      return false;
+    }
+
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    if (typeof value === 'string') {
+      return this.matchesEnvironment(value);
+    }
+
+    if (value.env) {
+      if (typeof value.env === 'boolean') {
+        return value.env;
+      }
+
+      return this.matchesEnvironment(value.env);
+    }
+
+    return false;
+  }
+
+  matchesEnvironment(value) {
+    let parts = value.split('&').map(x => x.trim().toLowerCase());
+    return parts.indexOf(this.environment) !== -1;
+  }
+};

--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -6,6 +6,7 @@ const fs = require('../file-system');
 const SourceInclusion = require('./source-inclusion').SourceInclusion;
 const DependencyInclusion = require('./dependency-inclusion').DependencyInclusion;
 const Utils = require('./utils');
+const BuildOptions = require('./build-options').BuildOptions;
 
 exports.Bundle = class {
   constructor(bundler, config) {
@@ -25,7 +26,7 @@ exports.Bundle = class {
       this.excludes = (this.includes.exclude || []).map(x => this.createMatcher(x));
       this.includes = this.includes.include.map(x => new SourceInclusion(this, x));
     }
-    this.buildOptions = bundler.interpretBuildOptions(config.options, bundler.buildOptions);
+    this.buildOptions = new BuildOptions(config.options, bundler.buildOptions.getAllOptions());
     this.requiresBuild = true;
     this.fileCache = {};
   }
@@ -148,7 +149,7 @@ exports.Bundle = class {
 
       for (let i = 0; i < files.length; ++i) {
         let currentFile = files[i];
-        let sourceMap = buildOptions.sourcemaps ? currentFile.sourceMap : undefined;
+        let sourceMap = buildOptions.isApplicable('sourcemaps') ? currentFile.sourceMap : undefined;
 
         function fileIsDependency(file) {
           return file
@@ -210,7 +211,7 @@ exports.Bundle = class {
         concat.add(undefined, this.writeLoaderCode(platform));
         contents = concat.content;
 
-        if (buildOptions.rev) {
+        if (buildOptions.isApplicable('rev')) {
           //Generate a unique hash based off of the bundle contents
           //Must generate hash after we write the loader config so that any other bundle changes (hash changes) can cause a new hash for the vendor file
           this.hash = generateHash(concat.content);
@@ -222,7 +223,7 @@ exports.Bundle = class {
         if (platform.index) {
           this.setIndexFileConfigTarget(platform, path.posix.join(outputDir, bundleFileName));
         }
-      } else if (buildOptions.rev) {
+      } else if (buildOptions.isApplicable('rev')) {
         //Generate a unique hash based off of the bundle contents
         //Must generate hash after we write the loader config so that any other bundle changes (hash changes) can cause a new hash for the vendor file
         this.hash = generateHash(concat.content);
@@ -237,8 +238,8 @@ exports.Bundle = class {
 
       console.log(`Writing ${bundleFileName}...`);
 
-      if (buildOptions.minify) {
-        let minificationOptions = { fromString: true };
+      if (buildOptions.isApplicable('minify')) {
+        let minificationOptions = Object.assign({ fromString: true }, buildOptions.getValue('minify.options'));
 
         if (needsSourceMap) {
           minificationOptions.inSourceMap = Convert.fromJSON(concat.sourceMap).toObject();

--- a/lib/build/bundler.js
+++ b/lib/build/bundler.js
@@ -4,6 +4,7 @@ const BundledSource = require('./bundled-source').BundledSource;
 const CLIOptions = require('../cli-options').CLIOptions;
 const LoaderPlugin = require('./loader-plugin').LoaderPlugin;
 const path = require('path');
+const BuildOptions = require('./build-options').BuildOptions;
 
 exports.Bundler = class {
   constructor(project, packageAnalyzer) {
@@ -20,7 +21,7 @@ exports.Bundler = class {
       rev: false
     };
 
-    this.buildOptions = this.interpretBuildOptions(project.build.options, defaultBuildOptions);
+    this.buildOptions = new BuildOptions(project.build.options, defaultBuildOptions);
     this.loaderOptions = project.build.loader;
 
     this.loaderConfig = {

--- a/lib/build/loader.js
+++ b/lib/build/loader.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const BuildOptions = require('./build-options').BuildOptions;
+
 exports.createLoaderCode = function createLoaderCode(platform, bundler) {
   let loaderCode;
   let loaderOptions = bundler.loaderOptions;
@@ -57,7 +59,7 @@ exports.createRequireJSConfig = function createRequireJSConfig(platform, bundler
   for (let i = 0; i < bundles.length; ++i) {
     let currentBundle = bundles[i];
     let currentName = currentBundle.config.name;
-    let buildOptions = bundler.interpretBuildOptions(currentBundle.config.options, bundler.buildOptions);
+    let buildOptions = new BuildOptions(currentBundle.config.options, bundler.buildOptions.getAllOptions());
     if (currentName === configName) { //skip over the vendor bundle
       continue;
     }
@@ -66,7 +68,7 @@ exports.createRequireJSConfig = function createRequireJSConfig(platform, bundler
       bundleMetadata[currentBundle.moduleId] = currentBundle.getBundledModuleIds();
     }
     //If build revisions are enabled, append the revision hash to the appropriate module id
-    config.paths[currentBundle.moduleId] = location + '/' + currentBundle.moduleId + (buildOptions.rev && currentBundle.hash ? '-' + currentBundle.hash : '');
+    config.paths[currentBundle.moduleId] = location + '/' + currentBundle.moduleId + (buildOptions.isApplicable('rev') && currentBundle.hash ? '-' + currentBundle.hash : '');
   }
 
   if (includeBundles) {

--- a/spec/lib/build/build-options.spec.js
+++ b/spec/lib/build/build-options.spec.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const BuildOptions = require('../../../lib/build/build-options').BuildOptions;
+const CLIOptionsMock = require('../../mocks/cli-options');
+
+describe('the BuildOptions module', () => {
+  let cliOptionsMock;
+
+  beforeEach(() => {
+    cliOptionsMock = new CLIOptionsMock();
+    cliOptionsMock.attach();
+  });
+
+  afterEach(() => {
+    cliOptionsMock.detach();
+  });
+
+  it('overrides default options with customized options', () => {
+    let buildOptions = new BuildOptions({ fromString: true }, { fromString: false });
+    expect(buildOptions.getAllOptions().fromString).toBe(true);
+  });
+
+  describe('the getAllOptions() function', () => {
+    it('returns the entire options object', () => {
+      let options = {
+        rev: 'dev & prod',
+        minify: true
+      };
+      let buildOptions = new BuildOptions({}, options);
+      expect(buildOptions.getAllOptions()).toEqual(options);
+    });
+  });
+
+  describe('the getValue() function', () => {
+    it('supports multi level options', () => {
+      let options = new BuildOptions({}, { foo: { bar: { value: 'someValue' } } }, 'dev');
+      expect(options.getValue('foo.bar').value).toBe('someValue');
+
+      options = new BuildOptions({}, { foo: { bar: { value: { options: true } } } }, 'dev');
+      expect(options.getValue('foo.bar').value.options).toBe(true);
+
+      options = new BuildOptions({}, { foo: { bar: 'abcd' } }, 'dev');
+      expect(options.getValue('foo.bar')).toBe('abcd');
+    });
+
+    it('supports one level options', () => {
+      let options = new BuildOptions({}, { foo: 'someValue' }, 'dev');
+      expect(options.getValue('foo')).toBe('someValue');
+    });
+
+    it('returns undefined when property is not defined', () => {
+      let options = new BuildOptions({}, { foo: 'someValue' }, 'dev');
+      expect(options.getValue('foobarbaz')).toBe(undefined);
+
+      options = new BuildOptions({}, { foo: 'someValue' }, 'dev');
+      expect(options.getValue('foo.bar.baz')).toBe(undefined);
+
+      options = new BuildOptions({}, { }, 'dev');
+      expect(options.getValue('foo.bar.baz')).toBe(undefined);
+    });
+  });
+
+  describe('the isApplicable', () => {
+    it('supports multi level options', () => {
+      let options = new BuildOptions({}, { foo: { bar: { env: 'dev & prod' } } }, 'dev');
+      expect(options.isApplicable('foo.bar')).toBe(true);
+
+      options = new BuildOptions({}, { foo: { bar: { env: 'dev & prod' } } }, 'staging');
+      expect(options.isApplicable('foo.bar')).toBe(false);
+
+      options = new BuildOptions({}, { foo: { bar: { env: true } } }, 'staging');
+      expect(options.isApplicable('foo.bar')).toBe(true);
+
+      options = new BuildOptions({}, { foo: { bar: { env: false } } }, 'staging');
+      expect(options.isApplicable('foo.bar')).toBe(false);
+    });
+
+    it('returns false if env not found', () => {
+      let options = new BuildOptions({}, { foo: { bar: { } } }, 'dev');
+      expect(options.isApplicable('foo.bar')).toBe(false);
+    });
+
+    it('supports first level options', () => {
+      let options = new BuildOptions({}, { foo: { env: 'dev & prod' } }, 'dev');
+      expect(options.isApplicable('foo')).toBe(true);
+
+      options = new BuildOptions({}, { foo: { env: 'dev & prod' } }, 'staging');
+      expect(options.isApplicable('foo')).toBe(false);
+    });
+
+    it('interprets strings', () => {
+      let options = new BuildOptions({}, { foo: 'dev & prod' }, 'dev');
+      expect(options.isApplicable('foo')).toBe(true);
+
+      options = new BuildOptions({}, { foo: { bar: { baz: 'dev & prod' } } }, 'dev');
+      expect(options.isApplicable('foo.bar.baz')).toBe(true);
+
+      options = new BuildOptions({}, { foo: 'dev & prod' }, 'staging');
+      expect(options.isApplicable('foo')).toBe(false);
+
+      options = new BuildOptions({}, { foo: { bar: { baz: 'dev & prod' } } }, 'staging');
+      expect(options.isApplicable('foo.bar.baz')).toBe(false);
+    });
+
+    it('supports booleans', () => {
+      let options = new BuildOptions({}, { foo: true }, 'dev');
+      expect(options.isApplicable('foo')).toBe(true);
+
+      options = new BuildOptions({}, { foo: false }, 'dev');
+      expect(options.isApplicable('foo')).toBe(false);
+    });
+  });
+});

--- a/spec/lib/build/bundle.spec.js
+++ b/spec/lib/build/bundle.spec.js
@@ -2,16 +2,25 @@
 
 const BundlerMock = require('../../mocks/bundler');
 const Bundle = require('../../../lib/build/bundle').Bundle;
+const CLIOptionsMock = require('../../mocks/cli-options');
 
 describe('the Bundle module', () => {
   let sut;
+  let cliOptionsMock;
 
   beforeEach(() => {
+    cliOptionsMock = new CLIOptionsMock();
+    cliOptionsMock.attach();
+
     let bundler = new BundlerMock();
     let config = {
       name: 'app-bundle.js'
     };
     sut = new Bundle(bundler, config);
+  });
+
+  afterEach(() => {
+    cliOptionsMock.detach();
   });
 
   it('only prepends items that are included in the build', () => {

--- a/spec/mocks/bundler.js
+++ b/spec/mocks/bundler.js
@@ -1,10 +1,14 @@
 'use strict';
 
+const BuildOptions = require('../../lib/build/build-options').BuildOptions;
+
 module.exports = class Bundler {
   constructor() {
     this.itemIncludedInBuild = jasmine.createSpy('itemIncludedInBuild');
     this.interpretBuildOptions = jasmine.createSpy('interpretBuildOptions');
     this.configureDependency = jasmine.createSpy('configureDependency');
     this.addFile = jasmine.createSpy('addFile');
+
+    this.buildOptions  = new BuildOptions({}, {});
   }
 };


### PR DESCRIPTION
closes https://github.com/aurelia/cli/issues/562

Currently the `build.options` section of `aurelia.json` is a bit limited, because you can only use strings and booleans as the option values. So in order to properly support https://github.com/aurelia/cli/issues/562 and future expansion, I decided to do a bit of refactoring to allow you to provide objects as well, allowing you to do this:

```
    "options": {
      "sourcemaps": "dev & stage",
      "minify": {
        "env": "dev & stage & prod",
        "options": {
          "max-line-len": 100000
        }
      },
      "rev": true
    },
```

It is backwards compatible with older versions of the CLI (and projects built by older versions of the CLI), so 

```
    "options": {
      "sourcemaps": "dev & stage",
      "minify": "stage & prod",
      "rev": true
    },
```

will still work.
