### PR TITLE
chore(gitignore): remove no related project files

### DIFF
--- a/lib/resources/content/gitignore
+++ b/lib/resources/content/gitignore
@@ -1,7 +1,7 @@
 # You may want to customise this file depending on your Operating System
 # and the editor you use.
 #
-# We recommend that you use a Global Gitignore files that is not related
+# We recommend that you use a Global Gitignore for files that is not related
 # to the project. (https://help.github.com/articles/ignoring-files/#create-a-global-gitignore)
 
 # OS

--- a/lib/resources/content/gitignore
+++ b/lib/resources/content/gitignore
@@ -1,3 +1,2 @@
 node_modules
-.idea
-.DS_STORE
+scripts

--- a/lib/resources/content/gitignore
+++ b/lib/resources/content/gitignore
@@ -1,2 +1,27 @@
+# You may want to customise this file depending on your Operating System
+# and the editor you use.
+#
+# We recommend that you use a Global Gitignore files that is not related
+# to the project. (https://help.github.com/articles/ignoring-files/#create-a-global-gitignore)
+
+# OS
+#
+# Ref: https://github.com/github/gitignore/blob/master/Global/macOS.gitignore
+# Ref: https://github.com/github/gitignore/blob/master/Global/Windows.gitignore
+# Ref: https://github.com/github/gitignore/blob/master/Global/Linux.gitignore
+.DS_STORE
+Thumbs.db
+
+# Editors
+#
+# Ref: https://github.com/github/gitignore/blob/master/Global
+# Ref: https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
+# Ref: https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore
+.idea
+.vscode
+
+# Dependencies
 node_modules
+
+# Compiled files
 scripts


### PR DESCRIPTION
Hey everyone !

`.idea` is editor related and `.DS_STORE` is OS related. Both of those files/folders should be inside [a global gitignore file](https://help.github.com/articles/ignoring-files/#create-a-global-gitignore) since they are not related to the project.

`scripts` folder is recreate by the CLI when you bundle your application, there's no need to push compiled file so it's better to remove them by default.