### PR TITLE
chore(circleci): resolve minimatch error and tests running on linux

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@
 
 machine:
   node:
-    version: 4.2.6
+    version: 7.9.0
 
 dependencies:
   pre:

--- a/spec/lib/build/package-analyzer.spec.js
+++ b/spec/lib/build/package-analyzer.spec.js
@@ -133,7 +133,7 @@ describe('The PackageAnalyzer', () => {
     sut.analyze('my-package')
     .then(description => {
       expect(description.loaderConfig.name).toBe('my-package');
-      expect(description.loaderConfig.path).toBe('..\\node_modules\\my-package\\index');
+      expect(description.loaderConfig.path).toBe(path.join('..', 'node_modules', 'my-package', 'index'));
       done();
     })
     .catch(e => done.fail(e));
@@ -150,7 +150,7 @@ describe('The PackageAnalyzer', () => {
     sut.analyze('my-package')
     .then(description => {
       expect(description.loaderConfig.name).toBe('my-package');
-      expect(description.loaderConfig.path).toBe('..\\node_modules\\my-package\\foobar\\my-main');
+      expect(description.loaderConfig.path).toBe(path.join('..', 'node_modules', 'my-package', 'foobar', 'my-main'));
       done();
     })
     .catch(e => done.fail(e));
@@ -166,7 +166,7 @@ describe('The PackageAnalyzer', () => {
     sut.analyze('my-package')
     .then(description => {
       expect(description.loaderConfig.name).toBe('my-package');
-      expect(description.loaderConfig.path).toBe('..\\node_modules\\my-package\\index');
+      expect(description.loaderConfig.path).toBe(path.join('..', 'node_modules', 'my-package', 'index'));
       done();
     })
     .catch(e => done.fail(e));

--- a/spec/lib/file-system.spec.js
+++ b/spec/lib/file-system.spec.js
@@ -115,10 +115,6 @@ describe('The file-system module', () => {
         return fs.readdir(writeDir + readDir);
       }).catch(fail).then(done);
     });
-
-    it('rejects if mkdirp returns an error', done => {
-      pending(`change file-system to mkdirp.mkdirp or more helpers.`);
-    });
   });
 
   describe('The readFile() function', () => {


### PR DESCRIPTION
should allow circleCI to run the tests correctly