### PR TITLE
feat(bundle-report) #633 adding config flag to write out simple bundle report

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -237,6 +237,26 @@ exports.Bundle = class {
 
       console.log(`Writing ${bundleFileName}...`);
 
+      if (buildOptions.bundleReport) {
+        let sbuffer = [];
+
+        sbuffer.push('>> ' + bundleFileName + ' total size : ' + (contents.length / 1024).toFixed(2) + 'kb, containing ' + files.length + ' files');
+        let sortedFiles = files.sort(function (a, b) {
+          if (a.contents.length > b.contents.length) {
+            return -1;
+          }
+          if (a.contents.length < b.contents.length) {
+            return 1;
+          }
+          return 0;
+        });
+        for (let i = 0; i < sortedFiles.length; ++i) {
+          let currentFile = sortedFiles[i];
+          sbuffer.push('  > ' + (currentFile.contents.length / 1024).toFixed(2) + 'kb ('+ ((currentFile.contents.length / contents.length) * 100).toFixed(2)+'%) - ' + currentFile.path );
+        }
+        fs.writeFile('bundle-report-' + bundleFileName + '.txt', sbuffer.join('\n'));
+      }
+
       if (buildOptions.minify) {
         let minificationOptions = { fromString: true };
 


### PR DESCRIPTION
Added a simple bundleReport option, which writes out a simple txt file containing a summary of the contents of the bundle being written, each bundle having a separate report file

```
"options": {
      "bundleReport": "dev & stage & prod"
    }
```

sample output
```
>> web-platform.js total size : 1816.78kb, containing 322 files
  > 261.76kb (14.41%) - C:\development\GW-Maintenance\frontend-projects\web-platform\node_modules\jquery\dist\jquery.js
  > 195.40kb (10.76%) - C:\development\GW-Maintenance\frontend-projects\web-platform\node_modules\highcharts\highcharts.js
  > 177.20kb (9.75%) - C:\development\GW-Maintenance\frontend-projects\web-platform\node_modules\aurelia-binding\dist\amd\aurelia-binding.js
  > 155.49kb (8.56%) - C:\development\GW-Maintenance\frontend-projects\web-platform\node_modules\aurelia-templating\dist\amd\aurelia-templating.js
  > 125.93kb (6.93%) - C:\development\GW-Maintenance\frontend-projects\web-platform\node_modules\moment\moment.js
  > 116.86kb (6.43%) - undefined
  > 83.34kb (4.59%) - C:\development\GW-Maintenance\frontend-projects\web-platform\node_modules\owl.carousel\dist\owl.carousel.js
  > 79.74kb (4.39%) - C:\development\GW-Maintenance\frontend-projects\web-platform\static-assets\js\jquery-ui.js
  > 68.12kb (3.75%) - C:\development\GW-Maintenance\frontend-projects\web-platform\node_modules\bootstrap-sass\assets\javascripts\bootstrap.js
  > 26.07kb (1.43%) - C:\development\GW-Maintenance\frontend-projects\web-platform\node_modules\aurelia-templating-binding\dist\amd\aurelia-templating-binding.js
  > 25.26kb (1.39%) - C:\development\GW-Maintenance\frontend-projects\web-platform\node_modules\aurelia-polyfills\dist\amd\aurelia-polyfills.js
  > 23.24kb (1.28%) - C:\development\GW-Maintenance\frontend-projects\web-platform\node_modules\aurelia-dependency-injection\dist\amd\aurelia-dependency-injection.js
  > 17.31kb (0.95%) - C:\development\GW-Maintenance\frontend-projects\web-platform\node_modules\aurelia-framework\dist\amd\aurelia-framework.js
... continues for alot of files
```

Couldn't see any unit tests covering bundle file creation, so didn't write any unit tests due to not wanting to reinvent the wheel if someone's already doing that else where

closes https://github.com/aurelia/cli/issues/633