### PR TITLE
fix(bundle): support quoteless script src attribute

### DIFF
--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -63,11 +63,11 @@ exports.escapeForRegex = function(str) {
 
 exports.createSrcFileRegex = function() {
   let parts = Array.prototype.slice.call(arguments);
-  let regexString = "\\b(?:src=(\"|')(.*))(";
+  let regexString = "\\b(?:src=(\"|')?(.*))(";
   for (let i = 0; i < parts.length; i ++) {
     regexString = regexString + exports.escapeForRegex(parts[i]) + (i < (parts.length - 1) ? '(\/|\\\\)' : '');
   }
-  regexString = regexString + "(.*?).js)(?:(\"|'))";
+  regexString = regexString + "(.*?).js)(?:(\"|')?)";
   return new RegExp(regexString);
 };
 


### PR DESCRIPTION
Fixes #639

Makes the capture groups optional for single/double quotes in the source file regular expression.