### PR TITLE
feat(build): allow minify options to be supplied

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -5,6 +5,7 @@ const Convert = require('./convert-source-map');
 const fs = require('../file-system');
 const SourceInclusion = require('./source-inclusion').SourceInclusion;
 const DependencyInclusion = require('./dependency-inclusion').DependencyInclusion;
+const Configuration = require('../configuration').Configuration;
 const Utils = require('./utils');
 
 exports.Bundle = class {
@@ -25,7 +26,7 @@ exports.Bundle = class {
       this.excludes = (this.includes.exclude || []).map(x => this.createMatcher(x));
       this.includes = this.includes.include.map(x => new SourceInclusion(this, x));
     }
-    this.buildOptions = bundler.interpretBuildOptions(config.options, bundler.buildOptions);
+    this.buildOptions = new Configuration(config.options, bundler.buildOptions.getAllOptions());
     this.requiresBuild = true;
     this.fileCache = {};
   }
@@ -148,7 +149,7 @@ exports.Bundle = class {
 
       for (let i = 0; i < files.length; ++i) {
         let currentFile = files[i];
-        let sourceMap = buildOptions.sourcemaps ? currentFile.sourceMap : undefined;
+        let sourceMap = buildOptions.isApplicable('sourcemaps') ? currentFile.sourceMap : undefined;
 
         function fileIsDependency(file) {
           return file
@@ -210,7 +211,7 @@ exports.Bundle = class {
         concat.add(undefined, this.writeLoaderCode(platform));
         contents = concat.content;
 
-        if (buildOptions.rev) {
+        if (buildOptions.isApplicable('rev')) {
           //Generate a unique hash based off of the bundle contents
           //Must generate hash after we write the loader config so that any other bundle changes (hash changes) can cause a new hash for the vendor file
           this.hash = generateHash(concat.content);
@@ -222,7 +223,7 @@ exports.Bundle = class {
         if (platform.index) {
           this.setIndexFileConfigTarget(platform, path.posix.join(outputDir, bundleFileName));
         }
-      } else if (buildOptions.rev) {
+      } else if (buildOptions.isApplicable('rev')) {
         //Generate a unique hash based off of the bundle contents
         //Must generate hash after we write the loader config so that any other bundle changes (hash changes) can cause a new hash for the vendor file
         this.hash = generateHash(concat.content);
@@ -237,8 +238,8 @@ exports.Bundle = class {
 
       console.log(`Writing ${bundleFileName}...`);
 
-      if (buildOptions.minify) {
-        let minificationOptions = { fromString: true };
+      if (buildOptions.isApplicable('minify')) {
+        let minificationOptions = Object.assign({ fromString: true }, buildOptions.getValue('minify'));
 
         if (needsSourceMap) {
           minificationOptions.inSourceMap = Convert.fromJSON(concat.sourceMap).toObject();

--- a/lib/build/bundler.js
+++ b/lib/build/bundler.js
@@ -3,6 +3,7 @@ const Bundle = require('./bundle').Bundle;
 const BundledSource = require('./bundled-source').BundledSource;
 const CLIOptions = require('../cli-options').CLIOptions;
 const LoaderPlugin = require('./loader-plugin').LoaderPlugin;
+const Configuration = require('../configuration').Configuration;
 const path = require('path');
 
 exports.Bundler = class {
@@ -20,7 +21,7 @@ exports.Bundler = class {
       rev: false
     };
 
-    this.buildOptions = this.interpretBuildOptions(project.build.options, defaultBuildOptions);
+    this.buildOptions = new Configuration(project.build.options, defaultBuildOptions);
     this.loaderOptions = project.build.loader;
 
     this.loaderConfig = {
@@ -51,26 +52,6 @@ exports.Bundler = class {
         bundler.addBundle(bundle);
       }))
     ).then(() => bundler);
-  }
-
-  interpretBuildOptions(options, defaultOptions) {
-    let env = this.environment;
-    options = Object.assign({}, defaultOptions, options);
-
-    for (let key in options) {
-      let value = options[key];
-
-      if (typeof value === 'boolean') {
-        continue;
-      } else if (typeof value === 'string') {
-        let parts = value.split('&').map(x => x.trim().toLowerCase());
-        options[key] = parts.indexOf(env) !== -1;
-      } else {
-        options[key] = false;
-      }
-    }
-
-    return options;
   }
 
   itemIncludedInBuild(item) {

--- a/lib/build/loader.js
+++ b/lib/build/loader.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Configuration = require('../configuration').Configuration;
+
 exports.createLoaderCode = function createLoaderCode(platform, bundler) {
   let loaderCode;
   let loaderOptions = bundler.loaderOptions;
@@ -57,7 +59,7 @@ exports.createRequireJSConfig = function createRequireJSConfig(platform, bundler
   for (let i = 0; i < bundles.length; ++i) {
     let currentBundle = bundles[i];
     let currentName = currentBundle.config.name;
-    let buildOptions = bundler.interpretBuildOptions(currentBundle.config.options, bundler.buildOptions);
+    let buildOptions = new Configuration(currentBundle.config.options, bundler.buildOptions.getAllOptions());
     if (currentName === configName) { //skip over the vendor bundle
       continue;
     }
@@ -66,7 +68,7 @@ exports.createRequireJSConfig = function createRequireJSConfig(platform, bundler
       bundleMetadata[currentBundle.moduleId] = currentBundle.getBundledModuleIds();
     }
     //If build revisions are enabled, append the revision hash to the appropriate module id
-    config.paths[currentBundle.moduleId] = location + '/' + currentBundle.moduleId + (buildOptions.rev && currentBundle.hash ? '-' + currentBundle.hash : '');
+    config.paths[currentBundle.moduleId] = location + '/' + currentBundle.moduleId + (buildOptions.isApplicable('rev') && currentBundle.hash ? '-' + currentBundle.hash : '');
   }
 
   if (includeBundles) {

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const CLIOptions = require('./cli-options').CLIOptions;
+
+exports.Configuration = class {
+  constructor(options, defaultOptions, environment) {
+    this.options = Object.assign({}, defaultOptions, options);
+    this.environment = environment || CLIOptions.getEnvironment();
+  }
+
+  getAllOptions() {
+    return this.options;
+  }
+
+  getValue(propPath) {
+    let split = propPath.split('.');
+    let cur = this.options;
+
+    for (let i = 0; i < split.length; i++) {
+      if (!cur) {
+        return undefined;
+      }
+
+      cur = cur[split[i]];
+    }
+
+    if (typeof cur === 'object') {
+      let keys = Object.keys(cur);
+      let result = undefined;
+
+      if (keys.indexOf('default') > -1 && typeof(cur.default) === 'object') {
+        result = cur.default;
+      }
+
+      for (let i = 0; i < keys.length; i++) {
+        if (this.matchesEnvironment(this.environment, keys[i])) {
+          if (typeof(cur[keys[i]]) === 'object') {
+            result = Object.assign(result || {}, cur[keys[i]]);
+          } else {
+            return cur[keys[i]];
+          }
+        }
+      }
+
+      return result;
+    }
+
+    return cur;
+  }
+
+  isApplicable(propPath) {
+    let value = this.getValue(propPath);
+
+    if (!value) {
+      return false;
+    }
+
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    if (typeof value === 'string') {
+      return this.matchesEnvironment(this.environment, value);
+    }
+
+    if (typeof value === 'object') {
+      return true;
+    }
+
+    return false;
+  }
+
+  matchesEnvironment(environment, value) {
+    let parts = value.split('&').map(x => x.trim().toLowerCase());
+    return parts.indexOf(environment) !== -1;
+  }
+};

--- a/spec/lib/build/bundle.spec.js
+++ b/spec/lib/build/bundle.spec.js
@@ -2,16 +2,25 @@
 
 const BundlerMock = require('../../mocks/bundler');
 const Bundle = require('../../../lib/build/bundle').Bundle;
+const CLIOptionsMock = require('../../mocks/cli-options');
 
 describe('the Bundle module', () => {
   let sut;
+  let cliOptionsMock;
 
   beforeEach(() => {
+    cliOptionsMock = new CLIOptionsMock();
+    cliOptionsMock.attach();
+
     let bundler = new BundlerMock();
     let config = {
       name: 'app-bundle.js'
     };
     sut = new Bundle(bundler, config);
+  });
+
+  afterEach(() => {
+    cliOptionsMock.detach();
   });
 
   it('only prepends items that are included in the build', () => {

--- a/spec/lib/configuration.spec.js
+++ b/spec/lib/configuration.spec.js
@@ -1,0 +1,295 @@
+'use strict';
+
+const Configuration = require('../../lib/configuration').Configuration;
+const CLIOptionsMock = require('../mocks/cli-options');
+
+describe('the Configuration module', () => {
+  let cliOptionsMock;
+
+  beforeEach(() => {
+    cliOptionsMock = new CLIOptionsMock();
+    cliOptionsMock.attach();
+  });
+
+  afterEach(() => {
+    cliOptionsMock.detach();
+  });
+
+  it('overrides default options with customized options', () => {
+    let config = new Configuration({ fromString: true }, { fromString: false });
+    expect(config.getAllOptions().fromString).toBe(true);
+  });
+
+  describe('the getAllOptions() function', () => {
+    it('returns the entire options object', () => {
+      let options = {
+        rev: 'dev & prod',
+        minify: true,
+        inject: { dev: { value: true } }
+      };
+      let config = new Configuration({}, options);
+      expect(config.getAllOptions()).toEqual(options);
+    });
+  });
+
+  describe('the getValue() function', () => {
+    it('supports multi level options', () => {
+      let options = new Configuration({}, {
+        foo: {
+          bar: {
+            dev: {
+              value: 'someValue'
+            },
+            staging: {
+              value: 'someOtherValue'
+            }
+          }
+        }
+      }, 'dev');
+      expect(options.getValue('foo.bar').value).toBe('someValue');
+
+      options = new Configuration({}, {
+        foo: {
+          bar: {
+            'dev & prod': {
+              value: 'someValue'
+            }
+          }
+        }
+      }, 'dev');
+      expect(options.getValue('foo.bar').value).toBe('someValue');
+
+      options = new Configuration({}, {
+        foo: {
+          bar: {
+            dev: {
+              value: {
+                options: true
+              }
+            }
+          }
+        }
+      }, 'dev');
+      expect(options.getValue('foo.bar').value.options).toBe(true);
+
+      options = new Configuration({}, {
+        foo: {
+          bar: 'abcd'
+        }
+      }, 'dev');
+      expect(options.getValue('foo.bar')).toBe('abcd');
+    });
+
+    it('supports one level options', () => {
+      let options = new Configuration({}, { foo: 'someValue' }, 'dev');
+      expect(options.getValue('foo')).toBe('someValue');
+    });
+
+    it('returns undefined when property is not defined', () => {
+      let options = new Configuration({}, { foo: 'someValue' }, 'dev');
+      expect(options.getValue('foobarbaz')).toBe(undefined);
+
+      options = new Configuration({}, { foo: 'someValue' }, 'dev');
+      expect(options.getValue('foo.bar.baz')).toBe(undefined);
+
+      options = new Configuration({}, { }, 'dev');
+      expect(options.getValue('foo.bar.baz')).toBe(undefined);
+    });
+
+    it('applies default config, then environment config', () => {
+      let options = new Configuration({}, {
+        foo: {
+          bar: {
+            default: {
+              cutoff: 15,
+              maxLength: 5000
+            },
+            dev: {
+              maxLength: 3000
+            }
+          }
+        }
+      }, 'dev');
+
+      expect(options.getValue('foo.bar')).toEqual({
+        cutoff: 15,
+        maxLength: 3000
+      });
+
+      options = new Configuration({}, {
+        foo: {
+          bar: {
+            dev: {
+              maxLength: 3000
+            }
+          }
+        }
+      }, 'dev');
+
+      expect(options.getValue('foo.bar')).toEqual({
+        maxLength: 3000
+      });
+
+      options = new Configuration({}, {
+        foo: {
+          bar: {
+            dev: {
+              maxLength: 3000
+            },
+            'dev & staging': {
+              cutoff: 15
+            }
+          }
+        }
+      }, 'dev');
+
+      expect(options.getValue('foo.bar')).toEqual({
+        maxLength: 3000,
+        cutoff: 15
+      });
+    });
+  });
+
+  describe('isApplicable', () => {
+    it('supports multi level options', () => {
+      let options = new Configuration({}, {
+        foo: {
+          bar: {
+            baz: 'dev & prod'
+          }
+        }
+      }, 'dev');
+      expect(options.isApplicable('foo.bar.baz')).toBe(true);
+
+      options = new Configuration({}, {
+        foo: {
+          bar: true
+        }
+      }, 'staging');
+      expect(options.isApplicable('foo.bar')).toBe(true);
+
+      options = new Configuration({}, {
+        foo: {
+          bar: {
+            dev: false,
+            staging: true
+          }
+        }
+      }, 'staging');
+      expect(options.isApplicable('foo.bar')).toBe(true);
+
+      options = new Configuration({}, {
+        foo: {
+          bar: {
+            dev: false,
+            'staging & prod': true
+          }
+        }
+      }, 'staging');
+      expect(options.isApplicable('foo.bar')).toBe(true);
+
+      options = new Configuration({}, {
+        foo: {
+          bar: false
+        }
+      }, 'staging');
+      expect(options.isApplicable('foo.bar')).toBe(false);
+    });
+
+    it('returns false if env not found', () => {
+      let options = new Configuration({}, {
+        foo: {
+          bar: {
+            staging: {
+              somevalue: 123
+            }
+          }
+        }
+      }, 'dev');
+      expect(options.isApplicable('foo.bar')).toBe(false);
+    });
+
+    it('supports first level options', () => {
+      let options = new Configuration({}, {
+        foo: 'dev & prod'
+      }, 'dev');
+      expect(options.isApplicable('foo')).toBe(true);
+
+      options = new Configuration({}, {
+        foo: 'dev & prod'
+      }, 'staging');
+      expect(options.isApplicable('foo')).toBe(false);
+    });
+
+    it('interprets strings', () => {
+      let options = new Configuration({}, { foo: 'dev & prod' }, 'dev');
+      expect(options.isApplicable('foo')).toBe(true);
+
+      options = new Configuration({}, {
+        foo: {
+          bar: {
+            baz: 'dev & prod'
+          }
+        }
+      }, 'dev');
+      expect(options.isApplicable('foo.bar.baz')).toBe(true);
+
+      options = new Configuration({}, { foo: 'dev & prod' }, 'staging');
+      expect(options.isApplicable('foo')).toBe(false);
+
+      options = new Configuration({}, {
+        foo: {
+          bar: {
+            baz: 'dev & prod'
+          }
+        }
+      }, 'staging');
+      expect(options.isApplicable('foo.bar.baz')).toBe(false);
+
+      options = new Configuration({}, {
+        foo: {
+          bar: {
+            'dev & prod': {
+              value: true
+            }
+          }
+        }
+      }, 'dev');
+      expect(options.isApplicable('foo.bar')).toBe(true);
+
+      options = new Configuration({}, {
+        foo: {
+          bar: {
+            'dev & prod': true
+          }
+        }
+      }, 'staging');
+      expect(options.isApplicable('foo.bar')).toBe(false);
+
+      options = new Configuration({}, {
+        foo: {
+          bar: {
+            'dev & prod': true
+          }
+        }
+      }, 'dev');
+      expect(options.isApplicable('foo.bar')).toBe(true);
+    });
+
+    it('supports booleans', () => {
+      let options = new Configuration({}, { foo: true }, 'dev');
+      expect(options.isApplicable('foo')).toBe(true);
+
+      options = new Configuration({}, { foo: false }, 'dev');
+      expect(options.isApplicable('foo')).toBe(false);
+    });
+
+    it('supports environments inside an object', () => {
+      let options = new Configuration({}, { foo: { dev: true, staging: false } }, 'dev');
+      expect(options.isApplicable('foo')).toBe(true);
+
+      options = new Configuration({}, { foo: { dev: false, staging: true } }, 'dev');
+      expect(options.isApplicable('foo')).toBe(false);
+    });
+  });
+});

--- a/spec/mocks/bundler.js
+++ b/spec/mocks/bundler.js
@@ -1,10 +1,14 @@
 'use strict';
 
+const Configuration = require('../../lib/configuration').Configuration;
+
 module.exports = class Bundler {
   constructor() {
     this.itemIncludedInBuild = jasmine.createSpy('itemIncludedInBuild');
     this.interpretBuildOptions = jasmine.createSpy('interpretBuildOptions');
     this.configureDependency = jasmine.createSpy('configureDependency');
     this.addFile = jasmine.createSpy('addFile');
+
+    this.buildOptions  = new Configuration({}, {});
   }
 };


### PR DESCRIPTION
closes https://github.com/aurelia/cli/issues/562

with these changes you can do this to supply options to the uglifier:

```
    "options": {
      "minify": {
       "dev": false,
       "default": {
        "fromString": true
       },
       "stage & prod": {
        "max-line-len": 100000
       } 
      },
      "sourcemaps": "dev & stage"
    },
```

@AStoker what do you think?