### PR TITLE
fix(dependencies): update gulp-sass version

### DIFF
--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -31,7 +31,7 @@
   "gulp-sourcemaps": "^2.0.0-alpha",
   "gulp-less": "^3.1.0",
   "gulp-postcss": "6.1.1",
-  "gulp-sass": "^2.3.2",
+  "gulp-sass": "^3.1.0",
   "gulp-stylus": "^2.5.0",
   "gulp-typescript": "^3.1.4",
   "gulp-tslint": "^5.0.0",


### PR DESCRIPTION
gulp-sass is dependant on node-sass and the current version (2.3.1) tries to download an old version of node-sass that apparently is not available on GitHub anymore. Changing the gulp-sass version to latest version (3.1.0) solves the problem.

To reproduce the problem just install a new project using Sass as the CSS Pre-processor. You'll see that gulp-sass cannot find node-sass version, thus cannot be installed.

Environment: CLI 0.30.0; NPM 5.0.3; Node 8.1.2; SO Windows 10