### PR TITLE
test: fix a test on path "..\\node_modules" which only works on win32

### DIFF
--- a/spec/lib/build/package-analyzer.spec.js
+++ b/spec/lib/build/package-analyzer.spec.js
@@ -171,7 +171,7 @@ describe('The PackageAnalyzer', () => {
     sut.analyze('my-package')
     .then(description => {
       expect(description.loaderConfig.name).toBe('my-package');
-      expect(description.loaderConfig.path).toBe('..\\node_modules\\my-package\\index');
+      expect(description.loaderConfig.path).toBe(path.join('..', 'node_modules', 'my-package', 'index'));
       done();
     })
     .catch(e => done.fail(e));


### PR DESCRIPTION
Previous test fails when running on non-win32 systems.