### PR TITLE
fix(bundle): support both Uglify v3 and v2.

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -239,16 +239,36 @@ exports.Bundle = class {
       console.log(`Writing ${bundleFileName}...`);
 
       if (buildOptions.isApplicable('minify')) {
-        let minificationOptions = Object.assign({ fromString: true }, buildOptions.getValue('minify'));
-
-        if (needsSourceMap) {
-          minificationOptions.inSourceMap = Convert.fromJSON(concat.sourceMap).toObject();
-          minificationOptions.outSourceMap = mapFileName;
-          minificationOptions.sourceRoot = mapSourceRoot;
-        }
 
         const UglifyJS = require('uglify-js'); //added to user project devDependencies
+        // fromString is not a supported option in v3
+        const isV3 = !!(UglifyJS.minify('', {fromString: true}).error);
+
+        let minificationOptions = {};
+        if (!isV3) minificationOptions.fromString = true;
+
+        let minifyOptions = buildOptions.getValue('minify');
+        if (typeof minifyOptions === 'object') {
+          Object.assign(minificationOptions, minifyOptions);
+        }
+
+        if (needsSourceMap) {
+          if (isV3) {
+            minificationOptions.sourceMap = {
+              content: concat.sourceMap,
+              filename: bundleFileName,
+              url: mapFileName,
+              root: mapSourceRoot
+            };
+          } else {
+            minificationOptions.inSourceMap = Convert.fromJSON(concat.sourceMap).toObject();
+            minificationOptions.outSourceMap = mapFileName;
+            minificationOptions.sourceRoot = mapSourceRoot;
+          }
+        }
+
         let minificationResult = UglifyJS.minify(String(contents), minificationOptions);
+        if (minificationResult.error) throw minificationResult.error;
 
         contents = minificationResult.code;
         mapContents = needsSourceMap ? Convert.fromJSON(minificationResult.map).toJSON() : undefined;

--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -51,6 +51,6 @@
   "@types/jasmine": "^2.2.0",
   "@types/node": "^6.0.45",
   "typescript": ">=1.9.0-dev || ^2.0.0",
-  "uglify-js": "^2.6.3",
+  "uglify-js": "^3.0.19",
   "vinyl-fs": "^2.4.3"
 }


### PR DESCRIPTION
Keep supporting Uglify v2.
Fix error when using Uglify v3.
Update `lib/dependencies.json` uglify-js version to latest 3.0.19

fixes #636