### PR TITLE
fix(source-maps): remove existing sourcemap links

### DIFF
--- a/lib/build/amodro-trace/write/packages.js
+++ b/lib/build/amodro-trace/write/packages.js
@@ -1,7 +1,8 @@
 'use strict';
 var defines = require('./defines'),
     lang = require('../lib/lang'),
-    parse = require('../lib/parse');
+    parse = require('../lib/parse'),
+    removeMapFileComments = require('../../convert-source-map').removeMapFileComments;
 
 /**
  * For modules that are inside a package config, this transform will write out
@@ -27,6 +28,7 @@ function packages(options) {
 
     contents = defines.toTransport(context, moduleName,
                                    filePath, contents, options);
+    contents = removeMapFileComments(contents);
 
     if (packageName && !hasPackageName) {
       contents += ';define(\'' + packageName + '\', [\'' + moduleName +
@@ -35,7 +37,6 @@ function packages(options) {
 
     return contents;
   };
-
 }
 
 /**


### PR DESCRIPTION
Some external libraries ship with sourcemaps with the dist package including a `sourcemapUrl` link. This link causes problems during bundling, and is specifically exposed by anonymous amd modules and SystemJS loader (RequireJS). This change modifies amodro to strip any existing `sourcemapURL` link from the source of a referenced library that is being bundled.

closes aurelia/cli#659, related to aurelia/cli#624