### PR TITLE
Add 'dot' option for Minimatch to allow hidden folders

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -50,7 +50,9 @@ exports.Bundle = class {
   }
 
   createMatcher(pattern) {
-    return new this.Minimatch(pattern);
+    return new this.Minimatch(pattern, {
+      dot: true
+    });
   }
 
   addDependency(description) {


### PR DESCRIPTION
To fix https://github.com/aurelia/cli/issues/335