### PR TITLE
fix(bundle): continue build in case of incorrect sourcemap

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -164,9 +164,14 @@ exports.Bundle = class {
 
           let parsedPath = path.parse(file.path);
 
-          let base64SourceMap = Convert.fromSource(file.contents.toString());
+          try {
+            let base64SourceMap = Convert.fromSource(file.contents.toString());
 
-          if (base64SourceMap) {
+            if (base64SourceMap) {
+              return null;
+            }
+          } catch (error) {
+            // we don't want the build to fail when a sourcemap file can't be parsed
             return null;
           }
 


### PR DESCRIPTION
we don't want the build to crash when a 3rd party dependency has invalid sourcemaps