### PR TITLE
fix(systemjs-bundling): include dependency name in bundle config

### DIFF
--- a/lib/build/dependency-inclusion.js
+++ b/lib/build/dependency-inclusion.js
@@ -60,7 +60,7 @@ exports.DependencyInclusion = class {
   }
 
   getAllModuleIds() {
-    return this.items.map(x => x.moduleId);
+    return [this.description.name].concat(this.items.map(x => x.moduleId));
   }
 
   getAllFiles() {


### PR DESCRIPTION
`Bundle.getBundledModuleIds` was only returning the ids of the traced files in the case of a package dependency. This change modifies `DependencyInclusion` to include the actual package name in the module ids for the dependency.

closes aurelia/cli#676