### PR TITLE
Added customBaseUrl to Require Loader

### DIFF
--- a/lib/build/loader.js
+++ b/lib/build/loader.js
@@ -72,6 +72,11 @@ exports.createRequireJSConfig = function createRequireJSConfig(platform, bundler
     config.paths[currentBundle.moduleId] = location + '/' + currentBundle.moduleId + (buildOptions.isApplicable('rev') && currentBundle.hash ? '-' + currentBundle.hash : '');
   }
 
+  if(bundler.project.paths.customBaseUrl)
+  {
+    config.baseUrl = bundler.project.paths.customBaseUrl + config.baseUrl;
+  }
+
   if (includeBundles) {
     config.bundles = bundleMetadata;
   }


### PR DESCRIPTION
Add customBaseUrl to the paths section in aurelia.json. When using this commit it will add the customBaseUrl before the current baseUrl.

The purpose is to allow loading the scripts from other domain than the webpage is served. If for example the HTML page is hosted in SharePoint online and you want to load the script from say Azure, you need a custom baseUrl.

`"paths": {
    "root": "src",
    "resources": "resources",
    "elements": "resources/elements",
    "attributes": "resources/attributes",
    "valueConverters": "resources/value-converters",
    "bindingBehaviors": "resources/binding-behaviors",
    "customBaseUrl": "http://localhost:9002/"
  },`