### PR TITLE
chore(versions): only update aurelia-cli on release

### DIFF
--- a/build/tasks/prepare-release.js
+++ b/build/tasks/prepare-release.js
@@ -26,7 +26,7 @@ gulp.task('prepare-release', function(callback){
     'lint',
     'bump-version',
     'changelog',
-    'update-dependenciesjs',
+    'update-cli-dependenciesjs',
     callback
   );
 });


### PR DESCRIPTION
Instead of updating all aurelia libraries on prepare-release, I think we should only update aurelia-cli automatically. We want to prevent that packages get updated on prepare-release that introduce breaking changes.

This change causes only aurelia-cli to be updated in dependencies.json when `gulp prepare-release` is called. The command `gulp update-all-dependenciesjs` updates all packages, that you need to manually run and test.