### PR TITLE
fix(webpack): remove comma from arguments

### DIFF
--- a/lib/commands/new/buildsystems/webpack/index.js
+++ b/lib/commands/new/buildsystems/webpack/index.js
@@ -37,7 +37,7 @@ module.exports = function(project, options) {
     ProjectItem.resource('build.json', 'tasks/build.json'),
     ProjectItem.resource('run.ext', 'tasks/run-webpack.ext', project.model.transpiler),
     ProjectItem.resource('run.json', 'tasks/run-webpack.json'),
-    ProjectItem.resource('environment.ext', 'tasks/environment.ext', project.model.transpiler),
+    ProjectItem.resource('environment.ext', 'tasks/environment.ext', project.model.transpiler)
   ).addToContent(
     ProjectItem.resource('index.ejs', 'content/index-webpack.ejs'),
     ProjectItem.resource('package-scripts.js', 'content/package-scripts.template.js')


### PR DESCRIPTION
version: 0.31.2

Trying to create a new project using webpack fails with following error:
```
ERROR [ProjectCreation] Failed to create the project due to an error: Unexpected token )
INFO [ProjectCreation] /home/sayem/.nvm/versions/node/v7.10.1/lib/node_modules/aurelia-cli/lib/commands/new/buildsystems/webpack/index.js:41
  ).addToContent(
  ^
SyntaxError: Unexpected token )
```