### PR TITLE
fix(npm script): add required dependency to start npm task

### DIFF
--- a/lib/commands/new/buildsystems/webpack/index.js
+++ b/lib/commands/new/buildsystems/webpack/index.js
@@ -58,6 +58,7 @@ module.exports = function(project, options) {
     'url-loader',
     'del',
     'css-loader',
+    'nps',
     'nps-utils',
     'file-loader',
     'json-loader',

--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -78,6 +78,7 @@
   "karma-typescript-preprocessor": "^0.2.1",
   "minimatch": "^3.0.2",
   "node-sass": "4.5.3",
+  "nps": "^5.7.1",
   "nps-utils": "1.2.0",
   "opn": "^5.1.0",
   "protractor": "^5.1.2",


### PR DESCRIPTION
In the generated project, the `npm start` task runs `nps` but the dependencies don't have that package so the task fails.

To be foolproof, the executable should be run from `./node_modules/.bin`, but I haven't changed the task because all the tasks in `package-scripts.js` assume that the users will have `node_modules/.bin` added to their path.