### PR TITLE
fix(webpack): add missing depencies fixes #727

### DIFF
--- a/lib/commands/new/buildsystems/webpack/index.js
+++ b/lib/commands/new/buildsystems/webpack/index.js
@@ -58,6 +58,7 @@ module.exports = function(project, options) {
     'url-loader',
     'del',
     'css-loader',
+    'nps',
     'nps-utils',
     'file-loader',
     'json-loader',


### PR DESCRIPTION
As described in #727, this fixes the missing `devDependencies` of `nps` for WebPack