### PR TITLE
fix(bundle): exclude source-maps when applicable

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -151,7 +151,8 @@ exports.Bundle = class {
 
       for (let i = 0; i < files.length; ++i) {
         let currentFile = files[i];
-        let sourceMap = buildOptions.isApplicable('sourcemaps') ? currentFile.sourceMap : undefined;
+        let sourceMapEnabled = buildOptions.isApplicable('sourcemaps');
+        let sourceMap = sourceMapEnabled ? currentFile.sourceMap : undefined;
 
         function fileIsDependency(file) {
           return file
@@ -198,12 +199,14 @@ exports.Bundle = class {
           return sourceMap;
         }
 
-        if (fileIsDependency(currentFile)) {
-          sourceMap = acquireSourceMapForDependency(currentFile);
-        }
-
-        if (sourceMap) {
-          needsSourceMap = true;
+        if (sourceMapEnabled) {
+          if (fileIsDependency(currentFile)) {
+            sourceMap = acquireSourceMapForDependency(currentFile);
+          }
+  
+          if (sourceMap) {
+            needsSourceMap = true;
+          }
         }
 
         concat.add(currentFile.path, currentFile.contents, sourceMap ? JSON.stringify(sourceMap) : undefined);


### PR DESCRIPTION
If a vendor bundle contains source maps, currently those source maps
are created/copied over to the dist folder despite source maps being
disabled in the aurelia options. This fix checks to make sure that
source maps should be enabled before making them.
Example:
[sourcemap-bug-test.zip](https://github.com/aurelia/cli/files/1264081/sourcemap-bug-test.zip)
