### PR TITLE
fix(importer): search for resources from package dist

### DIFF
--- a/lib/importer/services/resource-inclusion.js
+++ b/lib/importer/services/resource-inclusion.js
@@ -6,11 +6,12 @@ const glob = require('glob');
 
 let ResourceInclusion = class {
 
-  static inject() { return [UI, 'package']; }
+  static inject() { return [UI, 'package', 'project']; }
 
-  constructor(ui, pkg) {
+  constructor(ui, pkg, project) {
     this.ui = ui;
     this.package = pkg;
+    this.project = project;
   }
 
   getCSS() {
@@ -57,15 +58,10 @@ let ResourceInclusion = class {
   }
 
   getResources(globExpr) {
-    return this.glob(globExpr, { cwd: this.package.rootPath })
-    .then(files => files.map(file => {
-      let directoryFromPath = this.package.path.substring(this.package.path.lastIndexOf('/') + 1);
-      let directoryFromFile = file.split('/').shift();
-      if (directoryFromPath === directoryFromFile) {
-        file = file.substring(file.indexOf('/') + 1);
-      }
-      return path.posix.join(file);
-    }));
+    const distPath = path.resolve(process.cwd(), this.project.model.paths.root, this.package.path);
+
+    return this.glob(globExpr, { cwd: distPath })
+    .then(files => files.map(file => path.posix.join(file)));
   }
 
   glob(globExpr, options) {


### PR DESCRIPTION
Previously `au install` and `au import` were looking for resources (css files currently) from the package root, but this should be the package path (the distribution folder of the package) as anything outside of the dist folder is unreachable

I've updated the tests to reflect this, and this resolves the failing test that was made intentionally