### PR TITLE
fix(jsconfig): only create jsconfig for babel+vscode

### DIFF
--- a/lib/commands/new/buildsystems/webpack/editors/vscode.js
+++ b/lib/commands/new/buildsystems/webpack/editors/vscode.js
@@ -2,6 +2,12 @@
 const ProjectItem = require('../../../../../project-item').ProjectItem;
 
 module.exports = function(project) {
+  if (project.model.transpiler.id !== 'typescript') {
+    project.addToContent(
+      ProjectItem.resource('jsconfig.json', 'content/jsconfig-webpack.json')
+    );
+  }
+
   project.addToContent(
     ProjectItem.directory('.vscode').add(
       ProjectItem.resource('settings.json', 'content/settings.json'),

--- a/lib/commands/new/buildsystems/webpack/transpilers/babel.js
+++ b/lib/commands/new/buildsystems/webpack/transpilers/babel.js
@@ -11,8 +11,7 @@ module.exports = function(project) {
   project.addToContent(
     ProjectItem.resource('.eslintrc.json', 'content/eslintrc.json'),
     ProjectItem.resource('.babelrc.js', 'content/babelrc.webpack.js'),
-    ProjectItem.resource('.babelrc', 'content/babelrc.webpack'),
-    ProjectItem.resource('jsconfig.json', 'content/jsconfig-webpack.json')
+    ProjectItem.resource('.babelrc', 'content/babelrc.webpack')
   )
   .addToDevDependencies(
     'babel-eslint@7.2.3',


### PR DESCRIPTION
closes https://github.com/aurelia/cli/issues/723