### PR TITLE
feat(bundle): prepend and append now support environment specific dependencies

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -14,8 +14,8 @@ exports.Bundle = class {
     this.bundler = bundler;
     this.config = config;
     this.dependencies = [];
-    this.prepend = (config.prepend || []).filter(x => bundler.itemIncludedInBuild(x));
-    this.append = (config.append || []).filter(x => bundler.itemIncludedInBuild(x));
+    this.prepend = (config.prepend || []).filter(x => bundler.itemIncludedInBuild(x)).map(x => typeof x === 'string' ? x : x.path);
+    this.append = (config.append || []).filter(x => bundler.itemIncludedInBuild(x)).map(x => typeof x === 'string' ? x : x.path);
     this.moduleId = config.name.replace(path.extname(config.name), '');
     this.hash = '';
     this.includes = (config.source || []);

--- a/lib/commands/new/buildsystems/cli/index.js
+++ b/lib/commands/new/buildsystems/cli/index.js
@@ -44,7 +44,14 @@ module.exports = function(project, options) {
         name: 'vendor-bundle.js',
         prepend: [
           'node_modules/bluebird/js/browser/bluebird.core.js',
-          'node_modules/aurelia-cli/lib/resources/scripts/configure-bluebird.js'
+          {
+            "path": "node_modules/aurelia-cli/lib/resources/scripts/configure-bluebird-no-long-stacktraces.js",
+            "env": "stage & prod"
+          },
+          {
+            "path": "node_modules/aurelia-cli/lib/resources/scripts/configure-bluebird.js",
+            "env": "dev"
+          }
         ],
         dependencies: [
           'aurelia-binding',

--- a/lib/resources/scripts/configure-bluebird-no-long-stacktraces.js
+++ b/lib/resources/scripts/configure-bluebird-no-long-stacktraces.js
@@ -1,0 +1,7 @@
+//Configure Bluebird Promises.
+Promise.config({
+  longStackTraces: false,
+  warnings: {
+    wForgottenReturn: false
+  }
+});


### PR DESCRIPTION
This implements feature request https://github.com/aurelia/cli/issues/752
I added an extra bluebird config file without long stacktraces and changed the default generated aurelia.json file to selectively pick the right settings depending on the chosen environment