### PR TITLE
fix(gitignore): track vscode workspace files

### DIFF
--- a/lib/resources/content/gitignore
+++ b/lib/resources/content/gitignore
@@ -18,7 +18,11 @@ Thumbs.db
 # Ref: https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
 # Ref: https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore
 .idea
-.vscode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
 
 # Dependencies
 node_modules


### PR DESCRIPTION
Update according to https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore.