### PR TITLE
fix(dependencies) add gulp and typescript to the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,16 +33,17 @@
     "aurelia-polyfills": "^1.0.0",
     "esprima": "^4.0.0",
     "glob": "^7.1.1",
+    "gulp": "^4.0.0",
     "npm": "^3.10.8",
     "npm-which": "^3.0.1",
     "preprocess": "^3.1.0",
     "rfc6902": "^1.2.2",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "typescript": "^2.0.0"
   },
   "devDependencies": {
     "aurelia-tools": "^0.2.4",
     "babel-eslint": "^7.1.1",
-    "gulp": "^3.9.1",
     "gulp-bump": "^2.7.0",
     "gulp-conventional-changelog": "^1.1.3",
     "gulp-eslint": "^3.0.1",


### PR DESCRIPTION
the aurelia-cli cannot be used in its entirety without having `gulp@^4.0.0` and `typescript` installed. The aurelia-cli depends on them at least at these places during `au build`:

**gulp** (fails with `Error: Cannot find module 'gulp'`)
https://github.com/aurelia/cli/blob/ceb78602240e521c9592ceef537ca5a47ccfb256/lib/commands/gulp.js#L19

**gulp@^4.0.0** (fails with `TypeError: Cannot read property 'apply' of undefined`)
https://github.com/aurelia/cli/blob/ceb78602240e521c9592ceef537ca5a47ccfb256/lib/commands/gulp.js#L72

**typescript** (fails with `Error: Cannot find module 'typescript'`)
https://github.com/aurelia/cli/blob/ceb78602240e521c9592ceef537ca5a47ccfb256/lib/project.js#L221

The dependencies of the package.json should reflect, that the aurelia-cli requires these dependencies to be used. This is what is implemented in this branch.

This fixes #801 