### PR TITLE
Update Karma to fix intermitten unit test failure

### DIFF
--- a/lib/resources/test/require.aurelia-karma.js
+++ b/lib/resources/test/require.aurelia-karma.js
@@ -70,7 +70,7 @@
 
   function requireTests() {
     var TEST_REGEXP = /(spec)\.js$/i;
-    var allTestFiles = ['/base/test/unit/setup.js'];
+    var allTestFiles = [];
 
     Object.keys(window.__karma__.files).forEach(function(file) {
       if (TEST_REGEXP.test(file)) {
@@ -78,7 +78,9 @@
       }
     });
 
-    require(allTestFiles, window.__karma__.start);
+    require(['/base/test/unit/setup.js'], () => {
+      require(allTestFiles, window.__karma__.start);
+    });
   }
 
   karma.loaded = function() {}; // make it async

--- a/lib/resources/test/system.aurelia-karma.js
+++ b/lib/resources/test/system.aurelia-karma.js
@@ -32,7 +32,7 @@
 
   function requireTests() {
     var TEST_REGEXP = /(spec)\.js$/i;
-    var allTestFiles = ['/base/test/unit/setup.js'];
+    var allTestFiles = [];
 
     Object.keys(window.__karma__.files).forEach(function(file) {
       if (TEST_REGEXP.test(file)) {
@@ -40,7 +40,9 @@
       }
     });
 
-    require(allTestFiles, window.__karma__.start);
+    require(['/base/test/unit/setup.js'], () => {
+      require(allTestFiles, window.__karma__.start);
+    });
   }
 
   karma.loaded = function() {}; // make it async


### PR DESCRIPTION
Because it contains import for aurelia-polyfills that essential to execute any of the app files. Or else, it may break with "Reflect.getOwnMetadata is not a function" error.
Especially when the unit test is huge.

The require js files seems to load in parallel and asynchronously. So when there
are so many unit tests, sometimes Karma load other js files first before
the setup.ts file, which make further execution may fail (but
sometimes successful). More unit tests will have higher chance for Karma
to be failed due to setup.ts is loaded/required later.