### PR TITLE
fix(rjs-ts): add baseUrl to tsconfig

### DIFF
--- a/lib/resources/content/tsconfig.template.json
+++ b/lib/resources/content/tsconfig.template.json
@@ -12,7 +12,8 @@
     "experimentalDecorators": true,
     "allowJs": true,
     "moduleResolution": "node",
-    "lib": ["es2017", "dom"]
+    "lib": ["es2017", "dom"],
+    "baseUrl": "src",
     // @endif
     // @if bundler.id='webpack'
     "target": "es5",


### PR DESCRIPTION
This allows non-relative paths to work. `baseUrl` is already set when you choose webpack and typescript.