### PR TITLE
feat(build): add support for external modules

### DIFF
--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -58,6 +58,7 @@ exports.BundledSource = class {
     let bundler = this.bundler;
     let loaderConfig = bundler.loaderConfig;
     let loaderPlugins = bundler.loaderOptions.plugins;
+    let externalModules = bundler.loaderOptions.externalModules || {};
     let rootDir = process.cwd();
     let moduleId = this.moduleId || (this.moduleId = this.calculateModuleId(rootDir, loaderConfig));
     let that = this;
@@ -87,6 +88,13 @@ exports.BundledSource = class {
           return true;
         },
         fileRead: function(defaultRead, id, filePath) {
+          if (id in externalModules) {
+            let externalContentResult = makeModuleContent(externalModules[id], defaultRead, id, filePath);
+            if (externalContentResult) {
+              return externalContentResult;
+            }
+          }
+
           let location = calculateFileName(filePath);
           let found = bundler.getItemByPath(location);
 
@@ -208,4 +216,14 @@ function calculateFileName(filePath) {
   }
 
   return filePath;
+}
+
+function makeModuleContent(content, defaultRead, id, filePath) {
+  if (typeof content === 'function') {
+    return content(defaultRead, id, filePath);
+  }
+  if (Array.isArray(content)) {
+    let modules = content.map(m => `'${m}'`).join(',');
+    return `define([${modules}], function() { });`;
+  }
 }


### PR DESCRIPTION
Now you can inject stubs for modules that are only available at runtime and avoid `File not found or not accessible` console logs via `aurelia.json` or cli task.

Closes #802