### PR TITLE
feat(cli-bundler): add --open flag

### DIFF
--- a/lib/resources/tasks/run.js
+++ b/lib/resources/tasks/run.js
@@ -11,7 +11,7 @@ let serve = gulp.series(
   done => {
     browserSync({
       online: false,
-      open: false,
+      open: CLIOptions.hasFlag('open'),
       port: 9000,
       logLevel: 'silent',
       server: {

--- a/lib/resources/tasks/run.json
+++ b/lib/resources/tasks/run.json
@@ -11,6 +11,11 @@
       "name": "watch",
       "description": "Watches source files for changes and refreshes the app automatically.",
       "type": "boolean"
+    },
+    {
+      "name": "open",
+      "description": "Open the default browser at the application location.",
+      "type": "boolean"
     }
   ]
 }

--- a/lib/resources/tasks/run.ts
+++ b/lib/resources/tasks/run.ts
@@ -11,7 +11,7 @@ let serve = gulp.series(
   done => {
     browserSync({
       online: false,
-      open: false,
+      open: CLIOptions.hasFlag('open'),
       port: 9000,
       logLevel: 'silent',
       server: {


### PR DESCRIPTION
enable `--open` or `-o` flag as a flag for the `au run` task.
this will open the default browser at the application location.