### PR TITLE
fix(dependencies): add jest-matchers for karma tests using webpack

### DIFF
--- a/lib/commands/new/buildsystems/webpack/unit-test-runners/karma.js
+++ b/lib/commands/new/buildsystems/webpack/unit-test-runners/karma.js
@@ -25,7 +25,8 @@ module.exports = function(project) {
     'karma-mocha-reporter',
     'karma-webpack',
     'karma-coverage-istanbul-reporter',
-    'jest-jasmine2'
+    'jest-jasmine2',
+    'jest-matchers'
   );
 
   if (project.model.transpiler.id === 'babel') {

--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -69,6 +69,7 @@
   "jest": "20.0.4",
   "jest-jasmine2": "21.2.1",
   "jest-cli": "20.0.4",
+  "jest-matchers": "^20.0.3",
   "json-loader": "0.5.7",
   "html-loader": "0.4.5",
   "karma": "^0.13.22",


### PR DESCRIPTION
This references https://github.com/aurelia/cli/issues/782

I'm still getting the following error when creating new projects using the cli.

`ERROR in ./test/karma-bundle.js
Module not found: Error: Can't resolve 'jest-matchers' in 'D:\Dev\felix\au-webpack-babel\test'
 @ ./test/karma-bundle.js 52:15-39`