### PR TITLE
WIP fix(bundler): fix commonjs node id compatibility.

### DIFF
--- a/lib/build/bundler.js
+++ b/lib/build/bundler.js
@@ -29,7 +29,8 @@ exports.Bundler = class {
       paths: ensurePathsRelativelyFromRoot(project.paths || {}),
       packages: [],
       stubModules: [],
-      shim: {}
+      shim: {},
+      nodeIdCompat: true
     };
     Object.assign(this.loaderConfig, this.project.build.loader.config);
 

--- a/lib/importer/strategies/amodro.js
+++ b/lib/importer/strategies/amodro.js
@@ -76,6 +76,9 @@ let AmodroStrategy = class {
         readTransform: function(id, url, contents) {
           return cjsTransform(url, contents);
         }
+      },
+      {
+        nodeIdCompat: true
       }
     ).then(traceResult => {
       let traced = traceResult.traced;


### PR DESCRIPTION
Commonjs thinks "foo" and "foo.js" are same id, but AMD thinks they are two different ids. Passing `nodeIdCompat: true` to requirejs config to improve compatibility to whole range of commonjs packages. Ref: https://github.com/amodrojs/amodro-trace/issues/7