### PR TITLE
fix(cli build): reassign global.define.amd after assigning karma over…

### DIFF
--- a/lib/resources/test/require.aurelia-karma.js
+++ b/lib/resources/test/require.aurelia-karma.js
@@ -66,6 +66,7 @@
 
       return originalDefine(name, deps, m);
     }
+    global.define.amd = originalDefine.amd;
   }
 
   function requireTests() {


### PR DESCRIPTION
…ride function

aurelia/testing ComponentTester wasn't working. Bootstrapper failed to return with an error that there was no loader defined. Tracked the error down to a dependency reassigning window.require because define.amd was undefined.

aurelia/testing issue https://github.com/aurelia/testing/issues/71