### PR TITLE
fix: fix binary file copy on favicon.ico

### DIFF
--- a/lib/commands/new/buildsystems/webpack/index.js
+++ b/lib/commands/new/buildsystems/webpack/index.js
@@ -42,7 +42,7 @@ module.exports = function(project, options) {
     ProjectItem.resource('index.ejs', 'content/index-webpack.ejs'),
     ProjectItem.resource('package-scripts.js', 'content/package-scripts.template.js')
       .asTemplate(normalizeForPreprocess(model)),
-    ProjectItem.resource('static/favicon.ico', 'content/favicon.ico'),
+    ProjectItem.resource('static/favicon.ico', 'content/favicon.ico').binaryFile(),
     ProjectItem.resource('webpack.config.js', 'content/webpack.config.template.js')
       .asTemplate(model)
   ).addToDevDependencies(

--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -86,7 +86,7 @@ exports.ProjectTemplate = class {
       this.projectFolder,
       this.src,
       this.projectOutput.add(
-        ProjectItem.resource('favicon.ico', 'img/favicon.ico').skipIfExists()
+        ProjectItem.resource('favicon.ico', 'img/favicon.ico').skipIfExists().binaryFile()
       ),
       ProjectItem.jsonObject('package.json', this.package).mergeIfExists(),
       ProjectItem.resource('.editorconfig', 'content/editorconfig').skipIfExists(),
@@ -170,7 +170,7 @@ exports.ProjectTemplate = class {
       ProjectItem.jsonObject('package.json', this.package),
       ProjectItem.resource('.editorconfig', 'content/editorconfig'),
       ProjectItem.resource('.gitignore', 'content/gitignore'),
-      ProjectItem.resource('favicon.ico', 'img/favicon.ico')
+      ProjectItem.resource('favicon.ico', 'img/favicon.ico').binaryFile()
     );
 
     return this;

--- a/lib/file-system.js
+++ b/lib/file-system.js
@@ -64,8 +64,12 @@ exports.readdirSync = function(path) {
 };
 
 exports.readFile = function(path, encoding) {
+  if (encoding !== null) {
+    encoding = encoding || 'utf8';
+  }
+
   return new Promise((resolve, reject) => {
-    fs.readFile(path, encoding || 'utf8', (error, data) => {
+    fs.readFile(path, encoding, (error, data) => {
       if (error) reject(error);
       else resolve(data);
     });
@@ -75,7 +79,11 @@ exports.readFile = function(path, encoding) {
 exports.readFileSync = fs.readFileSync;
 
 exports.readFileSync = function(path, encoding) {
-  return fs.readFileSync(path, encoding || 'utf8');
+  if (encoding !== null) {
+    encoding = encoding || 'utf8';
+  }
+
+  return fs.readFileSync(path, encoding);
 };
 
 exports.copySync = function(sourceFile, targetFile) {

--- a/lib/project-item.js
+++ b/lib/project-item.js
@@ -52,6 +52,11 @@ exports.ProjectItem = class {
     return this;
   }
 
+  binaryFile() {
+    this._isBinaryFile = true;
+    return this;
+  }
+
   add() {
     if (!this.isDirectory) {
       throw new Error('You cannot add items to a non-directory.');
@@ -142,7 +147,7 @@ exports.ProjectItem = class {
         .catch(() => fs.mkdir(fullPath))
         .then(() => Utils.runSequentially(this.children, child => child.create(ui, fullPath)));
     } else if (this.sourcePath) {
-      return fs.readFile(this.sourcePath).then(data => {
+      return fs.readFile(this.sourcePath, this._isBinaryFile ? null : 'utf8').then(data => {
         return this._write(fullPath, data, ui);
       });
     } else if (this.jsonObject) {

--- a/spec/lib/file-system.spec.js
+++ b/spec/lib/file-system.spec.js
@@ -122,6 +122,13 @@ describe('The file-system module', () => {
       }).catch(fail).then(done);
     });
 
+    it('returns a promise resolving to raw buffer of the files content when encoding is null', done => {
+      fs.readFile(readFile.path, null).then(buf => {
+        expect(Buffer.isBuffer(buf)).toBe(true);
+        expect(buf.toString('utf8')).toBe(readFile.content);
+      }).catch(fail).then(done);
+    });
+
     it('rejects with ENOENT error', done => {
       fs.readFile(writeFile.path).then(() => {
         fail('expected promise to be rejected');
@@ -136,6 +143,12 @@ describe('The file-system module', () => {
     it('returns the files content', () => {
       expect(fs.readFileSync(readFile.path))
         .toBe(readFile.content);
+    });
+
+    it('returns raw buffer of files content when encoding is null', () => {
+      let buf = fs.readFileSync(readFile.path, null);
+      expect(Buffer.isBuffer(buf)).toBe(true);
+      expect(buf.toString('utf8')).toBe(readFile.content);
     });
 
     it('throws an ENOENT error', () => {


### PR DESCRIPTION
Set encoding:null on binary file resource.
fs.readFile returns raw buffer.
fs.writeFile ignores our default 'utf8' encoding when
incoming data is a buffer.

Closes #688.