### PR TITLE
fix(importer): support nodejs module default main file "index.js" when "main" is missing in package.json

### DIFF
--- a/lib/importer/strategies/amodro.js
+++ b/lib/importer/strategies/amodro.js
@@ -6,6 +6,9 @@ const path = require('path');
 const amodroTrace = require('../../build/amodro-trace');
 const cjsTransform = require('../../build/amodro-trace/read/cjs');
 
+// nodejs default main is index.js
+const DEFAULT_MAIN = 'index.js';
+
 let AmodroStrategy = class {
 
   static inject() { return ['package']; }
@@ -16,7 +19,15 @@ let AmodroStrategy = class {
 
   applies() {
     if (!this.package.main) {
-      logger.debug('This package did not specify a "main" file in package.json. Skipping');
+      let defaultMainPath = path.join(process.cwd(), 'node_modules', this.package.name, DEFAULT_MAIN);
+
+      if (fs.existsSync(defaultMainPath)) {
+        this.package.main = DEFAULT_MAIN;
+        return true;
+      }
+
+      logger.debug('This package neither specified a "main" file in package.json, ' +
+                   'nor provided default ' + DEFAULT_MAIN + ' file. Skipping');
       return false;
     }
 


### PR DESCRIPTION
When "main" is missing in package.json, nodejs uses
default main file "index.js", it will complain when
default main file is missing.
This fix supports nodejs module with missing "main"
in package.json. It solves importing issue on nodejs
module "date-fns". #831 is related, that PR solves
tracing issue on "date-fns".