### PR TITLE
fix(stylus): don't stop watch on error

### DIFF
--- a/lib/resources/tasks/process-stylus.js
+++ b/lib/resources/tasks/process-stylus.js
@@ -2,11 +2,14 @@ import gulp from 'gulp';
 import changedInPlace from 'gulp-changed-in-place';
 import sourcemaps from 'gulp-sourcemaps';
 import stylus from 'gulp-stylus';
+import plumber from 'gulp-plumber';
+import notify from 'gulp-notify';
 import project from '../aurelia.json';
 import {build} from 'aurelia-cli';
 
 export default function processCSS() {
   return gulp.src(project.cssProcessor.source)
+    .pipe(plumber({ errorHandler: notify.onError('Error: <%= error.message %>') }))
     .pipe(changedInPlace({firstPass: true}))
     .pipe(sourcemaps.init())
     .pipe(stylus())

--- a/lib/resources/tasks/process-stylus.ts
+++ b/lib/resources/tasks/process-stylus.ts
@@ -2,11 +2,14 @@ import * as gulp from 'gulp';
 import * as changedInPlace from 'gulp-changed-in-place';
 import * as sourcemaps from 'gulp-sourcemaps';
 import * as stylus from 'gulp-stylus';
+import * as plumber from 'gulp-plumber';
+import * as notify from 'gulp-notify';
 import * as project from '../aurelia.json';
 import {build} from 'aurelia-cli';
 
 export default function processCSS() {
   return gulp.src(project.cssProcessor.source)
+    .pipe(plumber({ errorHandler: notify.onError('Error: <%= error.message %>') }))
     .pipe(changedInPlace({firstPass:true}))
     .pipe(sourcemaps.init())
     .pipe(stylus())


### PR DESCRIPTION
fixes: https://github.com/aurelia/cli/issues/829

## what was happening 
gulp-stylus is throwing on error
which prevents watch in some way 
https://github.com/gulpjs/gulp/issues/71

## implemented fix
I've found that we already use plumber to swallow some errors in transpile task and copied imports and pipe configuretions to process-css for stylus
