### PR TITLE
fix: removing "Tracing..." console logging

### DIFF
--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -64,8 +64,6 @@ exports.BundledSource = class {
     let that = this;
     let modulePath = this.path;
 
-    console.log(`Tracing ${moduleId}...`);
-
     for (let i = 0, ii = loaderPlugins.length; i < ii; ++i) {
       let current = loaderPlugins[i];
 


### PR DESCRIPTION
Unnecessary logging that clutters the console and makes it harder to spot the real issues you might have.

For example, we have ~200 modules in our project, meaning we get ~200 lines of log every time the bundles are regenerated, which happens every time you change a file (triggered by `gulp.watch`).