### PR TITLE
refactor(bundler): uses uglify-es in place of uglify-js

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -291,7 +291,22 @@ exports.Bundle = class {
       }
 
       if (buildOptions.isApplicable('minify')) {
-        const UglifyJS = require('uglify-es');
+        let UglifyJS;
+
+        try {
+          UglifyJS = require('uglify-es');
+        } catch (e) {
+          logger.warn(
+            'uglify-es package not available: Attempting to use uglify-js.'
+          );
+          logger.warn(
+            'Consider adding the uglify-es package to your npm dependencies ' +
+            'if you intend to support ES6 code minification.'
+          );
+
+          UglifyJS = require('uglify-js');
+        }
+
         // fromString is not a supported option in v3
         const isV3 = !!(UglifyJS.minify('', {fromString: true}).error);
 

--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -291,7 +291,7 @@ exports.Bundle = class {
       }
 
       if (buildOptions.isApplicable('minify')) {
-        const UglifyJS = require('uglify-js');
+        const UglifyJS = require('uglify-es');
         // fromString is not a supported option in v3
         const isV3 = !!(UglifyJS.minify('', {fromString: true}).error);
 

--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -291,21 +291,7 @@ exports.Bundle = class {
       }
 
       if (buildOptions.isApplicable('minify')) {
-        let UglifyJS;
-
-        try {
-          UglifyJS = require('uglify-es');
-        } catch (e) {
-          logger.warn(
-            'uglify-es package not available: Attempting to use uglify-js.'
-          );
-          logger.warn(
-            'Consider adding the uglify-es package to your npm dependencies ' +
-            'if you intend to support ES6 code minification.'
-          );
-
-          UglifyJS = require('uglify-js');
-        }
+        const UglifyJS = require('uglify-es');
 
         // fromString is not a supported option in v3
         const isV3 = !!(UglifyJS.minify('', {fromString: true}).error);

--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -8,6 +8,7 @@ const DependencyInclusion = require('./dependency-inclusion').DependencyInclusio
 const Configuration = require('../configuration').Configuration;
 const Utils = require('./utils');
 const logger = require('aurelia-logging').getLogger('Bundle');
+const UglifyJS = require('uglify-es');
 
 exports.Bundle = class {
   constructor(bundler, config) {
@@ -291,32 +292,20 @@ exports.Bundle = class {
       }
 
       if (buildOptions.isApplicable('minify')) {
-        const UglifyJS = require('uglify-es');
-
-        // fromString is not a supported option in v3
-        const isV3 = !!(UglifyJS.minify('', {fromString: true}).error);
-
         let minificationOptions = {};
-        if (!isV3) minificationOptions.fromString = true;
-
         let minifyOptions = buildOptions.getValue('minify');
+
         if (typeof minifyOptions === 'object') {
           Object.assign(minificationOptions, minifyOptions);
         }
 
         if (needsSourceMap) {
-          if (isV3) {
-            minificationOptions.sourceMap = {
-              content: concat.sourceMap,
-              filename: bundleFileName,
-              url: mapFileName,
-              root: mapSourceRoot
-            };
-          } else {
-            minificationOptions.inSourceMap = Convert.fromJSON(concat.sourceMap).toObject();
-            minificationOptions.outSourceMap = mapFileName;
-            minificationOptions.sourceRoot = mapSourceRoot;
-          }
+          minificationOptions.sourceMap = {
+            content: concat.sourceMap,
+            filename: bundleFileName,
+            url: mapFileName,
+            root: mapSourceRoot
+          };
         }
 
         let minificationResult = UglifyJS.minify(String(contents), minificationOptions);

--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -213,7 +213,7 @@ exports.ProjectTemplate = class {
       'gulp',
       'minimatch',
       'through2',
-      'uglify-js',
+      'uglify-es',
       'vinyl-fs'
     );
 

--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -98,7 +98,7 @@
   "ts-loader": "^4.0.1",
   "tslint": "^5.9.1",
   "typescript": "^2.7.2",
-  "uglify-js": "^3.3.15",
+  "uglify-es": "^3.3.9",
   "url-loader": "^1.0.1",
   "vinyl-fs": "^3.0.2",
   "wait-on": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "npm-which": "^3.0.1",
     "preprocess": "^3.1.0",
     "rfc6902": "^1.2.2",
-    "semver": "^5.3.0",
-    "uglify-es": "^3.3.9"
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "aurelia-tools": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "puppeteer": "^1.1.1",
     "require-dir": "^0.3.1",
     "run-sequence": "^1.2.2",
+    "uglify-es": "^3.3.9",
     "yargs": "^7.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "npm-which": "^3.0.1",
     "preprocess": "^3.1.0",
     "rfc6902": "^1.2.2",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "uglify-es": "^3.3.9"
   },
   "devDependencies": {
     "aurelia-tools": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "npm-which": "^3.0.1",
     "preprocess": "^3.1.0",
     "rfc6902": "^1.2.2",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "uglify-es": "^3.3.9"
   },
   "devDependencies": {
     "aurelia-tools": "^0.2.4",
@@ -55,7 +56,6 @@
     "puppeteer": "^1.1.1",
     "require-dir": "^0.3.1",
     "run-sequence": "^1.2.2",
-    "uglify-es": "^3.3.9",
     "yargs": "^7.0.2"
   }
 }


### PR DESCRIPTION
With better support of ES6+ in modern browsers and the introduction
of babel-preset-env it's possible to serve ES6 code to clients able
to consume it. This change uses uglify-es in place of ugliify-js to
handle minification that supports ES6.

**uglify-es is API/CLI compatible with uglify-js@3.**
**uglify-es is not backwards compatible with uglify-js@2.**

Issue #490 