### PR TITLE
fix(run-webpack.ts): copy the https property from devServer to opts

### DIFF
--- a/lib/resources/tasks/run-webpack.ts
+++ b/lib/resources/tasks/run-webpack.ts
@@ -20,7 +20,8 @@ function runWebpack(done) {
     open: project.platform.open,
     stats: {
       colors: require('supports-color')
-    }
+    },
+    https: config.devServer.https
   } as any;
 
   if (!CLIOptions.hasFlag('watch')) {


### PR DESCRIPTION
Running with `devServer.https: true` currently does not work because the property is not copied over. This PR fixes that. See this [SO question](https://stackoverflow.com/questions/49687797/serving-https-in-aurelia-typescript-webpack-dev-setup/49704139#49704139).