### PR TITLE
fix(cli): default bundler is webpack, so move to position 1

### DIFF
--- a/lib/commands/new/new-application.json
+++ b/lib/commands/new/new-application.json
@@ -133,6 +133,11 @@
       "stateProperty": "loaderBundler",
       "options": [
         {
+          "displayName": "Webpack",
+          "description": "A powerful bundler",
+          "value": "webpack"
+        },
+        {
           "displayName": "RequireJS",
           "description": "A file and module loader for JavaScript.",
           "value": "requirejs"
@@ -141,11 +146,6 @@
           "displayName": "SystemJS",
           "description": "Dynamic ES module loader",
           "value": "systemjs"
-        },
-        {
-          "displayName": "Webpack",
-          "description": "A powerful bundler",
-          "value": "webpack"
         }
       ]
     },


### PR DESCRIPTION
Because index 0 is used as a means of classifying an option as being (Default) when you choose custom in the CLI at present, RequireJS is presented in the UI as the default. However, Webpack is now the default. The fix for this is to move Webpack to the top of the list so the code on line 155 `text += ' (Default)';` applies to Webpack.