### PR TITLE
fix(tsconfig.template.json): fix incorrect files glob

### DIFF
--- a/lib/resources/content/tsconfig.template.json
+++ b/lib/resources/content/tsconfig.template.json
@@ -31,11 +31,7 @@
     ]
     // @endif
   },
-  "exclude": [
-    "node_modules",
-    "aurelia_project"
-  ],
-  "filesGlob": [
+  "include": [
     "./src/**/*.ts",
     "./test/**/*.ts",
     "./custom_typings/**/*.d.ts"


### PR DESCRIPTION
Change "filesGlob" to "include" so that it works consistently across editors ("filesGlob" is specific to atom).

Remove "exclude" to avoid confusion because those globs are already implicitly excluded. They have no effect.

See https://github.com/aurelia/webpack-plugin/issues/143#issuecomment-381603048