### PR TITLE
fix(dependencies): lock webpack version to 4.1.1

### DIFF
--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -102,7 +102,7 @@
   "url-loader": "^1.0.1",
   "vinyl-fs": "^3.0.2",
   "wait-on": "^2.1.0",
-  "webpack": "^4.1.1",
+  "webpack": "4.1.1",
   "webpack-cli": "^2.0.12",
   "webpack-dev-server": "^3.1.1",
   "webpack-hot-middleware": "^2.21.2"


### PR DESCRIPTION
Temporarily locked to avoid breaking changed in about 4.4.0 which saw a switch from extract-text-webpack-plugin to mini-css-extract-plugin, preventing production build in the current configuration

see #868