### PR TITLE
fix(jest): update usage of jest.runCli

### DIFF
--- a/lib/resources/tasks/jest.js
+++ b/lib/resources/tasks/jest.js
@@ -13,7 +13,7 @@ export default (cb) => {
 
   process.env.BABEL_TARGET = 'node';
 
-  jest.runCLI(options, [path.resolve(__dirname, '../../')], (result) => {
+  jest.runCLI(options, [path.resolve(__dirname, '../../')]).then((result) => {
     if (result.numFailedTests || result.numFailedTestSuites) {
       cb(new gutil.PluginError('gulp-jest', { message: 'Tests Failed' }));
     } else {

--- a/lib/resources/tasks/jest.ts
+++ b/lib/resources/tasks/jest.ts
@@ -12,7 +12,7 @@ export default (cb) => {
     Object.assign(options, { watch: true});
   }
 
-  jest.runCLI(options, [path.resolve(__dirname, '../../')], (result) => {
+  jest.runCLI(options, [path.resolve(__dirname, '../../')]).then((result) => {
     if(result.numFailedTests || result.numFailedTestSuites) {
       cb(new gutil.PluginError('gulp-jest', { message: 'Tests Failed' }));
     } else {


### PR DESCRIPTION
jest.runCli returns a promise. This change updates the usage of jest.runCli to use the promise rather than pass in a callback which never will get executed.

closes #896