### PR TITLE
fix: enforce single aurelia-binding in webpack bundle

### DIFF
--- a/lib/resources/content/webpack.config.template.js
+++ b/lib/resources/content/webpack.config.template.js
@@ -38,6 +38,9 @@ module.exports = ({production, server, extractCss, coverage, analyze} = {}) => (
     extensions: ['.js'],
     // @endif
     modules: [srcDir, 'node_modules'],
+    // Enforce single aurelia-binding, to avoid v1/v2 duplication due to
+    // out-of-date dependencies on 3rd party aurelia plugins
+    alias: { 'aurelia-binding': path.resolve(__dirname, 'node_modules/aurelia-binding') }
   },
   entry: {
     app: ['aurelia-bootstrapper'],


### PR DESCRIPTION
aurelia/binding#702 this is to avoid v1/v2 duplication due to out-of-date dependencies on 3rd party aurelia plugins.
