### PR TITLE
feat: use terser to replace uglifyjs for better es6 support

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -1,6 +1,7 @@
 'use strict';
 const path = require('path');
 const os = require('os');
+const Terser = require('terser');
 const Convert = require('./convert-source-map');
 const fs = require('../file-system');
 const SourceInclusion = require('./source-inclusion').SourceInclusion;
@@ -291,12 +292,10 @@ exports.Bundle = class {
       }
 
       if (buildOptions.isApplicable('minify')) {
-        const UglifyJS = require('uglify-js');
-        // fromString is not a supported option in v3
-        const isV3 = !!(UglifyJS.minify('', {fromString: true}).error);
-
-        let minificationOptions = {};
-        if (!isV3) minificationOptions.fromString = true;
+        // Terser fast minify mode
+        // https://github.com/fabiosantoscode/terser#terser-fast-minify-mode
+        // It's a good balance on size and speed to turn off compress.
+        let minificationOptions = {compress: true};
 
         let minifyOptions = buildOptions.getValue('minify');
         if (typeof minifyOptions === 'object') {
@@ -304,21 +303,15 @@ exports.Bundle = class {
         }
 
         if (needsSourceMap) {
-          if (isV3) {
-            minificationOptions.sourceMap = {
-              content: concat.sourceMap,
-              filename: bundleFileName,
-              url: mapFileName,
-              root: mapSourceRoot
-            };
-          } else {
-            minificationOptions.inSourceMap = Convert.fromJSON(concat.sourceMap).toObject();
-            minificationOptions.outSourceMap = mapFileName;
-            minificationOptions.sourceRoot = mapSourceRoot;
-          }
+          minificationOptions.sourceMap = {
+            content: concat.sourceMap,
+            filename: bundleFileName,
+            url: mapFileName,
+            root: mapSourceRoot
+          };
         }
 
-        let minificationResult = UglifyJS.minify(String(contents), minificationOptions);
+        let minificationResult = Terser.minify(String(contents), minificationOptions);
         if (minificationResult.error) throw minificationResult.error;
 
         contents = minificationResult.code;

--- a/lib/commands/new/project-template.js
+++ b/lib/commands/new/project-template.js
@@ -213,7 +213,6 @@ exports.ProjectTemplate = class {
       'gulp',
       'minimatch',
       'through2',
-      'uglify-js',
       'vinyl-fs'
     );
 

--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -102,7 +102,6 @@
   "ts-loader": "^4.0.1",
   "tslint": "^5.9.1",
   "typescript": "^2.7.2",
-  "uglify-js": "^3.3.15",
   "url-loader": "^1.0.1",
   "vinyl-fs": "^3.0.2",
   "wait-on": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -31,18 +31,19 @@
     "aurelia-dependency-injection": "^1.0.0",
     "aurelia-logging": "^1.2.0",
     "aurelia-polyfills": "^1.0.0",
+    "babel-polyfill": "^6.0.0 || ^7.0.0 || ^8.0.0",
+    "babel-register": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "esprima": "^4.0.0",
     "glob": "^7.1.1",
     "gulp": "^4.0.0",
     "npm": "^6.1.0",
     "npm-which": "^3.0.1",
+    "opn": "^5.0.0",
     "preprocess": "^3.1.0",
     "rfc6902": "^1.2.2",
     "semver": "^5.3.0",
-    "typescript": "^1.0.0 || ^2.0.0 || ^3.0.0",
-    "opn": "^5.0.0",
-    "babel-register": "^6.0.0 || ^7.0.0 || ^8.0.0",
-    "babel-polyfill": "^6.0.0 || ^7.0.0 || ^8.0.0"
+    "terser": "^3.8.1",
+    "typescript": "^1.0.0 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "aurelia-tools": "^0.2.4",


### PR DESCRIPTION
Terser is the current active fork of uglify-es. This is not only required to support babel targeting es6, but also improve compatibility of any vendor js code which uses "const".

closes #883, #490, supersedes #864