### PR TITLE
fix: fix environment check (--env or NODE_ENV)

### DIFF
--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,4 +1,21 @@
 'use strict';
+const fs = require('./file-system');
+
+function definedEnvironments() {
+  let envs = [];
+  // read user defined environment files
+  let files;
+  try {
+    files = fs.readdirSync('aurelia_project/environments');
+  } catch (e) {
+    // ignore
+  }
+  files && files.forEach(file => {
+    const m = file.match(/^(.+)\.(t|j)s$/);
+    if (m) envs.push(m[1]);
+  });
+  return envs;
+}
 
 exports.CLIOptions = class {
   constructor() {
@@ -13,11 +30,27 @@ exports.CLIOptions = class {
   }
 
   getEnvironment() {
-    let NODE_ENV;
-    let env = this.getFlagValue('env') || (process.env.NODE_ENV ? NODE_ENV = process.env.NODE_ENV : undefined) || 'dev';
-    if (NODE_ENV) {
-      console.log(`The selected Node Environment (${NODE_ENV}) is not a preconfigured option ('dev', 'stage', and 'prod')`);
+    if (this._env) return this._env;
+
+    let env = this.getFlagValue('env') || process.env.NODE_ENV || 'dev';
+    const envs = definedEnvironments();
+
+    if (!envs.includes(env)) {
+      // normalize NODE_ENV production/development (Node.js convention) to prod/dev
+      // only if user didn't define production.js or development.js
+      if (env === 'production' && envs.includes('prod')) {
+        env = 'prod';
+      } else if (env === 'development' && envs.includes('dev')) {
+        env = 'dev';
+      } else if (env !== 'dev') {
+        // forgive missing aurelia_project/environments/dev.js as dev is our default env
+        console.error(`The selected environment "${env}" is not defined in your aurelia_project/environments folder.`);
+        process.exit(1);
+        return;
+      }
     }
+
+    this._env = env;
     return env;
   }
 

--- a/spec/lib/cli-options.spec.js
+++ b/spec/lib/cli-options.spec.js
@@ -1,9 +1,23 @@
 'use strict';
 describe('The cli-options', () => {
   let cliOptions;
+  let mockfs;
 
   beforeEach(() => {
+    mockfs = require('mock-fs');
+    const fsConfig = {
+      'aurelia_project/environments/dev.js': 'content',
+      'aurelia_project/environments/stage.js': 'content',
+      'aurelia_project/environments/prod.js': 'content'
+    };
+    mockfs(fsConfig);
+
     cliOptions = new(require('../../lib/cli-options').CLIOptions)();
+  });
+
+  afterEach(() => {
+    delete process.env.NODE_ENV;
+    mockfs.restore();
   });
 
   describe('The CLIOptions', () => {
@@ -22,6 +36,108 @@ describe('The cli-options', () => {
           expect(cliOptions.taskName()).toBe(files[file]);
         }
       }
+    });
+
+    it('gets env from arg --env', () => {
+      cliOptions.args = ['build', '--env', 'prod'];
+      expect(cliOptions.getEnvironment()).toBe('prod');
+    });
+
+    it('gets env from NODE_ENV', () => {
+      process.env.NODE_ENV = 'dev';
+      cliOptions.args = ['build'];
+      expect(cliOptions.getEnvironment()).toBe('dev');
+    });
+
+    it('normalizes env from production to prod', () => {
+      cliOptions.args = ['build', '--env', 'production'];
+      expect(cliOptions.getEnvironment()).toBe('prod');
+    });
+
+    it('does not normalizes env from production to prod if production.js is defined', () => {
+      const fsConfig = {
+        'aurelia_project/environments/development.js': 'content',
+        'aurelia_project/environments/stage.js': 'content',
+        'aurelia_project/environments/production.js': 'content'
+      };
+      mockfs(fsConfig);
+      cliOptions.args = ['build', '--env', 'production'];
+      expect(cliOptions.getEnvironment()).toBe('production');
+    });
+
+    it('normalizes env from development to dev', () => {
+      cliOptions.args = ['build', '--env', 'development'];
+      expect(cliOptions.getEnvironment()).toBe('dev');
+    });
+
+    it('does not normalizes env from development to dev if development.js is defined', () => {
+      const fsConfig = {
+        'aurelia_project/environments/development.js': 'content',
+        'aurelia_project/environments/stage.js': 'content',
+        'aurelia_project/environments/production.js': 'content'
+      };
+      mockfs(fsConfig);
+      cliOptions.args = ['build', '--env', 'development'];
+      expect(cliOptions.getEnvironment()).toBe('development');
+    });
+
+    it('terminates when env is not defined by an env file', () => {
+      let oldExit = process.exit;
+      let spy = jasmine.createSpy('exit');
+      process.exit = spy;
+
+      cliOptions.args = ['build', '--env', 'unknown'];
+      cliOptions.getEnvironment();
+      expect(spy).toHaveBeenCalledWith(1);
+      process.exit = oldExit;
+    });
+
+    it('normalizes NODE_ENV from production to prod', () => {
+      process.env.NODE_ENV = 'production';
+      cliOptions.args = ['build'];
+      expect(cliOptions.getEnvironment()).toBe('prod');
+    });
+
+    it('does not normalizes NODE_ENV from production to prod if production.js is defined', () => {
+      const fsConfig = {
+        'aurelia_project/environments/development.js': 'content',
+        'aurelia_project/environments/stage.js': 'content',
+        'aurelia_project/environments/production.js': 'content'
+      };
+      mockfs(fsConfig);
+      process.env.NODE_ENV = 'production';
+      cliOptions.args = ['build'];
+      expect(cliOptions.getEnvironment()).toBe('production');
+    });
+
+    it('normalizes NODE_ENV from development to dev', () => {
+      process.env.NODE_ENV = 'development';
+      cliOptions.args = ['build'];
+      expect(cliOptions.getEnvironment()).toBe('dev');
+    });
+
+    it('does not normalizes env from development to dev if development.js is defined', () => {
+      const fsConfig = {
+        'aurelia_project/environments/development.js': 'content',
+        'aurelia_project/environments/stage.js': 'content',
+        'aurelia_project/environments/production.js': 'content'
+      };
+      mockfs(fsConfig);
+      process.env.NODE_ENV = 'development';
+      cliOptions.args = ['build'];
+      expect(cliOptions.getEnvironment()).toBe('development');
+    });
+
+    it('terminates when NODE_ENV is not defined by an env file', () => {
+      let oldExit = process.exit;
+      let spy = jasmine.createSpy('exit');
+      process.exit = spy;
+
+      process.env.NODE_ENV = 'unknown';
+      cliOptions.args = ['build'];
+      cliOptions.getEnvironment();
+      expect(spy).toHaveBeenCalledWith(1);
+      process.exit = oldExit;
     });
   });
 });

--- a/spec/lib/cli.spec.js
+++ b/spec/lib/cli.spec.js
@@ -23,7 +23,6 @@ describe('The cli', () => {
     const fsConfig = {};
     fsConfig[dir] = {};
     fsConfig['package.json'] = {};
-
     mockfs(fsConfig);
   });
 


### PR DESCRIPTION
Check env (either from --env or NODE_ENV) against user defined env files (aurelia_project/environments/*).
Normalize Node.js NODE_ENV convention production/development to prod/dev, but only if user didn't define production.js or development.js.
Stop the process immediately if env file is missing.

closes #912