### PR TITLE
fix: fix regression on npm/yarn path when it has white space

### DIFF
--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -29,7 +29,7 @@ exports.NPM = class {
   }
 
   installCommand(executablePath, packages) {
-    let cmd = `${executablePath} install`;
+    let cmd = `"${executablePath}" install`;
     if (packages && packages.length > 0) {
       cmd += ` ${packages.join(' ')}`;
     }

--- a/lib/package-managers/yarn.js
+++ b/lib/package-managers/yarn.js
@@ -10,7 +10,7 @@ exports.Yarn = class extends npm {
   }
 
   installCommand(executablePath, packages) {
-    let cmd = `${executablePath}`;
+    let cmd = `"${executablePath}"`;
     if (packages && packages.length > 0) {
       cmd += ` add ${packages.join(' ')}`;
     }


### PR DESCRIPTION
@JeroenVinke quotes are back. Sorry about that.