### PR TITLE
fix(bundler): fix a regression on missing yaml file for some users

### DIFF
--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -253,9 +253,15 @@ exports.BundledSource = class {
 
     let moduleIds = Array.from(new Set(deps)) // unique
       .map(stripPluginPrefixOrSubfix)
-      // don't bother with local dependency in src,
-      // as we bundled all of local js/html/css files.
-      .filter(d => this.dependencyInclusion || d[0] !== '.')
+      .filter(d => {
+        // any dep requested by a npm package file
+        if (this.dependencyInclusion) return true;
+        // For local src, pick up all absolute dep.
+        if (d[0] !== '.') return true;
+        // For relative dep, as we bundled all of local js/html/css files,
+        // only pick up unknown ext that might be missed by gulp tasks.
+        return Utils.couldMissGulpPreprocess(d);
+      })
       .map(d => absoluteModuleId(moduleId, d))
       .filter(d => {
         // ignore false replacment

--- a/lib/build/bundler.js
+++ b/lib/build/bundler.js
@@ -5,6 +5,7 @@ const CLIOptions = require('../cli-options').CLIOptions;
 const LoaderPlugin = require('./loader-plugin').LoaderPlugin;
 const Configuration = require('../configuration').Configuration;
 const path = require('path');
+const fs = require('../file-system');
 const Utils = require('./utils');
 const logger = require('aurelia-logging').getLogger('Bundler');
 const stubCoreNodejsModule = require('./stub-core-nodejs-module');
@@ -205,12 +206,12 @@ exports.Bundler = class {
                 }
 
                 // process normally if result is not recognizable
-                return this.addNpmResource(d);
+                return this.addMissingDep(d);
               },
               // proceed normally after error
               err => {
                 logger.error(err);
-                return this.addNpmResource(d);
+                return this.addMissingDep(d);
               }
             );
           }
@@ -237,6 +238,23 @@ exports.Bundler = class {
 
   getDependencyInclusions() {
     return this.bundles.reduce((a, b) => a.concat(b.getDependencyInclusions()), []);
+  }
+
+  addMissingDep(id) {
+    const localFilePath = path.resolve(this.project.paths.root, id);
+
+    // load additional local file missed by gulp tasks,
+    // this could be json/yaml file that user wanted in
+    // aurelia.json 'text!' plugin
+    if (Utils.couldMissGulpPreprocess(id) && fs.existsSync(localFilePath)) {
+      this.addFile({
+        path: localFilePath,
+        contents: fs.readFileSync(localFilePath)
+      });
+      return Promise.resolve();
+    }
+
+    return this.addNpmResource(id);
   }
 
   addNpmResource(id) {

--- a/lib/build/utils.js
+++ b/lib/build/utils.js
@@ -6,6 +6,11 @@ const tmpDir = require('os').tmpdir();
 
 exports.knownExtensions = ['.js', '.json', '.css', '.svg', '.html'];
 
+exports.couldMissGulpPreprocess = function(id) {
+  const ext = path.extname(id).toLowerCase();
+  return ext && ext !== '.js' && ext !== '.html' && ext !== '.css';
+};
+
 // require.resolve(packageName) cannot resolve package has no main.
 // for instance: font-awesome v4.7.0
 // manually try resolve paths

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-cli",
-  "version": "0.34.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spec/lib/build/bundled-source.spec.js
+++ b/spec/lib/build/bundled-source.spec.js
@@ -104,7 +104,7 @@ describe('the BundledSource module', () => {
   it('transforms local js file', () => {
     let file = {
       path: path.resolve(cwd, 'src/foo/bar/loo.js'),
-      contents: "define(['./a', 'lo/rem', 'text!./loo.html', 'text!foo.html'], function(a,r){});"
+      contents: "define(['./a', 'lo/rem', 'text!./loo.yaml', 'text!foo.html'], function(a,r){});"
     };
 
     let bs = new BundledSource(bundler, file);
@@ -120,9 +120,9 @@ describe('the BundledSource module', () => {
     bs._getUseCache = () => undefined;
 
     let deps = bs.transform();
-    expect(deps).toEqual(['lo/rem', 'foo.html']); // relative dep is ignored
+    expect(deps).toEqual(['lo/rem', 'foo/bar/loo.yaml', 'foo.html']); // relative dep is ignored
     expect(bs.requiresTransform).toBe(false);
-    expect(bs.contents).toBe("define('foo/bar/loo',['./a', 'lo/rem', 'text!./loo.html', 'text!foo.html'], function(a,r){});");
+    expect(bs.contents).toBe("define('foo/bar/loo',['./a', 'lo/rem', 'text!./loo.yaml', 'text!foo.html'], function(a,r){});");
     expect(bundler.configTargetBundle.addAlias).toHaveBeenCalledWith('b8/loo', 'foo/bar/loo');
   });
 

--- a/spec/lib/build/util.spec.js
+++ b/spec/lib/build/util.spec.js
@@ -75,3 +75,16 @@ describe('the Utils.moduleIdWithPlugin function', () => {
   });
 });
 
+describe('the Utils.couldMissGulpPreprocess function', () => {
+  it('returns false for js/html/css files', () => {
+    expect(Utils.couldMissGulpPreprocess('foo/bar')).toBeFalsy();
+    expect(Utils.couldMissGulpPreprocess('foo/bar.js')).toBeFalsy();
+    expect(Utils.couldMissGulpPreprocess('foo/bar.html')).toBeFalsy();
+    expect(Utils.couldMissGulpPreprocess('bar.css')).toBeFalsy();
+  });
+
+  it('returns true for unknown file extension', () => {
+    expect(Utils.couldMissGulpPreprocess('foo/bar.json')).toBeTruthy();
+    expect(Utils.couldMissGulpPreprocess('foo/bar.yaml')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Additional files like yaml were not processed by any gulp tasks. Previously amodro-trace was able to pull them in directly from file system. This fix mimics the same behaviour.

closes #930