### PR TITLE
chore(deps): update to latest typescript

### DIFF
--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -98,7 +98,7 @@
   "ts-node": "^7.0.0",
   "ts-loader": "^4.0.1",
   "tslint": "^5.9.1",
-  "typescript": "^2.7.2",
+  "typescript": "^3.1.0",
   "url-loader": "^1.0.1",
   "vinyl-fs": "^3.0.2",
   "wait-on": "^2.1.0",


### PR DESCRIPTION
a new scaffold should start with the currently latest typescript as with major 3 there are new features which are e.g required by Aurelia Store.