### PR TITLE
fix(bundler): bypass a nasty terser compress bug by using fast-minify-mode

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -364,7 +364,8 @@ exports.Bundle = class {
         // Terser fast minify mode
         // https://github.com/fabiosantoscode/terser#terser-fast-minify-mode
         // It's a good balance on size and speed to turn off compress.
-        let minificationOptions = {compress: true};
+        // Turn off compress also bypasses https://github.com/terser-js/terser/issues/120
+        let minificationOptions = {compress: false};
 
         let minifyOptions = buildOptions.getValue('minify');
         if (typeof minifyOptions === 'object') {


### PR DESCRIPTION
The original code supposed to use fast-minify-mode, but somehow it did not. This fix turns on fast-minify-mode, that disables compress. The resulting minified size is surprisingly almost as small as normal mode, but it only uses a quarter of the time. https://github.com/terser-js/terser#terser-fast-minify-mode

closes #928