### PR TITLE
fix(webpack): use webpack4 hook that replaced deprecated plugin api

### DIFF
--- a/lib/resources/tasks/build-webpack.js
+++ b/lib/resources/tasks/build-webpack.js
@@ -23,7 +23,7 @@ function buildWebpack(done) {
     compiler.watch({}, onBuild);
   } else {
     compiler.run(onBuild);
-    compiler.plugin('done', () => done());
+    compiler.hooks.done.tap('AureliaCLI', done);
   }
 }
 

--- a/lib/resources/tasks/build-webpack.ts
+++ b/lib/resources/tasks/build-webpack.ts
@@ -23,7 +23,7 @@ function buildWebpack(done) {
     compiler.watch({}, onBuild);
   } else {
     compiler.run(onBuild);
-    compiler.plugin('done', () => done());
+    compiler.hooks.done.tap('AureliaCLI', done);
   }
 }
 


### PR DESCRIPTION
Thanks @oising for the fix. @jods4 recommended using a meaningful tap name.

closes #923