### PR TITLE
chore(bundler): use loose mode for amd/cjs transform

### DIFF
--- a/lib/build/amodro-trace/read/es.js
+++ b/lib/build/amodro-trace/read/es.js
@@ -5,6 +5,6 @@ const transform = require('@babel/core').transform;
 module.exports = function es(fileName, fileContents) {
   return transform(fileContents, {
     babelrc: false,
-    plugins: ['@babel/plugin-transform-modules-amd']
+    plugins: [['@babel/plugin-transform-modules-amd', {loose: true}]]
   }).code;
 };

--- a/lib/commands/new/buildsystems/cli/transpilers/babel.js
+++ b/lib/commands/new/buildsystems/cli/transpilers/babel.js
@@ -4,7 +4,7 @@ const ProjectItem = require('../../../../../project-item').ProjectItem;
 module.exports = function(project) {
   project.model.transpiler.options = {
     'plugins': [
-      '@babel/plugin-transform-modules-amd'
+      ['@babel/plugin-transform-modules-amd', {loose: true}]
     ]
   };
 

--- a/lib/project.js
+++ b/lib/project.js
@@ -209,7 +209,7 @@ function installBabel() {
   require('@babel/register')({
     babelrc: false,
     plugins: [
-      '@babel/plugin-transform-modules-commonjs'
+      ['@babel/plugin-transform-modules-commonjs', {loose: true}]
     ],
     only: [/aurelia_project/]
   });


### PR DESCRIPTION
Since upgraded to babel7, preset-env uses "module":false, we have to explicitly pass "loose":true to additional amd/cjs transform plugin.