### PR TITLE
fix(webpack.config.template.js): webpack resolving child node_modules

### DIFF
--- a/lib/resources/content/webpack.config.template.js
+++ b/lib/resources/content/webpack.config.template.js
@@ -25,12 +25,12 @@ const cssRules = [
   // @if cssProcessor.id='postcss'
   {
     loader: 'postcss-loader',
-    options: { plugins: () => [require('autoprefixer')({ browsers: ['last 2 versions'] })]}
+    options: { plugins: () => [require('autoprefixer')({ browsers: ['last 2 versions'] })] }
   }
   // @endif
 ];
 
-module.exports = ({production, server, extractCss, coverage, analyze, karma} = {}) => ({
+module.exports = ({ production, server, extractCss, coverage, analyze, karma } = {}) => ({
   resolve: {
     // @if transpiler.id='typescript'
     extensions: ['.ts', '.js'],
@@ -38,7 +38,7 @@ module.exports = ({production, server, extractCss, coverage, analyze, karma} = {
     // @if transpiler.id='babel'
     extensions: ['.js'],
     // @endif
-    modules: [srcDir, 'node_modules'],
+    modules: [srcDir, nodeModulesDir],
     // Enforce single aurelia-binding, to avoid v1/v2 duplication due to
     // out-of-date dependencies on 3rd party aurelia plugins
     alias: { 'aurelia-binding': path.resolve(__dirname, 'node_modules/aurelia-binding') }
@@ -57,7 +57,7 @@ module.exports = ({production, server, extractCss, coverage, analyze, karma} = {
   optimization: {
     // Use splitChunks to breakdown the vendor bundle into smaller files
     // https://webpack.js.org/plugins/split-chunks-plugin/
-    splitChunks: { 
+    splitChunks: {
       chunks: "initial",
       cacheGroups: {
         default: false, // Disable the built-in groups (default and vendors)
@@ -121,8 +121,8 @@ module.exports = ({production, server, extractCss, coverage, analyze, karma} = {
         test: /\.css$/i,
         issuer: [{ not: [{ test: /\.html$/i }] }],
         use: extractCss ? [{
-            loader: MiniCssExtractPlugin.loader
-          },
+          loader: MiniCssExtractPlugin.loader
+        },
           'css-loader'
         ] : ['style-loader', ...cssRules]
       },
@@ -171,8 +171,9 @@ module.exports = ({production, server, extractCss, coverage, analyze, karma} = {
       // @endif
       { test: /\.html$/i, loader: 'html-loader' },
       // @if transpiler.id='babel'
-      { test: /\.js$/i, loader: 'babel-loader', exclude: nodeModulesDir,
-        options: coverage ? { sourceMap: 'inline', plugins: [ 'istanbul' ] } : {},
+      {
+        test: /\.js$/i, loader: 'babel-loader', exclude: nodeModulesDir,
+        options: coverage ? { sourceMap: 'inline', plugins: ['istanbul'] } : {},
       },
       // @endif
       // @if transpiler.id='typescript'
@@ -202,7 +203,7 @@ module.exports = ({production, server, extractCss, coverage, analyze, karma} = {
       'Promise': 'bluebird'
     }),
     new ModuleDependenciesPlugin({
-      'aurelia-testing': [ './compile-spy', './view-spy' ]
+      'aurelia-testing': ['./compile-spy', './view-spy']
     }),
     new HtmlWebpackPlugin({
       template: 'index.ejs',


### PR DESCRIPTION
Addressing #961, when a symlinked package (i.e. a lerna monorepo) exists in node_modules, the child node_modules are resolved in webpack, creating duplicate module ids like './node_modules/symlinked-package/node_modules/some-dependency/index.js' in addition to './node_modules/some-dependency/index.js'.