### PR TITLE
fix(bundler): fix unstable sorting for shim modules

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -158,6 +158,12 @@ exports.Bundle = class {
     // concatenated in the same order, so revision hash won't change.
     let bundleFiles = this.getBundledFiles()
       .sort((a, b) => {
+        // alphabetical sorting based on moduleId
+        if (a.moduleId > b.moduleId) return 1;
+        if (b.moduleId > a.moduleId) return -1;
+        return 0;
+      })
+      .sort((a, b) => {
         // for shim with deps, make sure they are in proper order
         if (a.dependencyInclusion && b.dependencyInclusion) {
           let aPackageName = a.dependencyInclusion.description.name;
@@ -170,10 +176,6 @@ exports.Bundle = class {
           // b must be after a
           if (bDeps && bDeps.indexOf(aPackageName) !== -1) return -1;
         }
-
-        // normal sorting based on moduleId
-        if (a.moduleId > b.moduleId) return 1;
-        if (b.moduleId > a.moduleId) return -1;
         return 0;
       });
 


### PR DESCRIPTION
Previous sorting algorithm mixed alphabetical order and shim order, it could lead to rock-paper-scissor situation (means it could choose to honour alphabetical order above shim order). The new sorting takes two steps, first it sorts alphabetically, then sorts shims. This ensure we only breaks alphabetical order, not shim order.

fixes #955