### PR TITLE
feat(esnext): use babel polyfill to enable async/await syntax for esnext projects

### DIFF
--- a/lib/commands/new/buildsystems/cli/index.js
+++ b/lib/commands/new/buildsystems/cli/index.js
@@ -62,7 +62,8 @@ module.exports = function(project, options) {
           {
             'path': 'node_modules/aurelia-cli/lib/resources/scripts/configure-bluebird.js',
             'env': 'dev'
-          }
+          },
+          'node_modules/@babel/polyfill/browser.js'
         ],
         dependencies: [
           // only needs packages not explicitly depend

--- a/lib/resources/src/main-webpack.js
+++ b/lib/resources/src/main-webpack.js
@@ -1,3 +1,4 @@
+import '@babel/polyfill';
 import environment from './environment';
 import {PLATFORM} from 'aurelia-pal';
 import * as Bluebird from 'bluebird';


### PR DESCRIPTION
In AMD (cli bundler) env, somehow babel polyfill has some trouble, use prepend to bypass AMD. The down side of prepend is that it is 90K in size, bypassed babel preset-env's optimisation.

closes #959