### PR TITLE
chore(webpack.config.template.js): alias not needed w/ absolute resolve

### DIFF
--- a/lib/resources/content/webpack.config.template.js
+++ b/lib/resources/content/webpack.config.template.js
@@ -38,10 +38,7 @@ module.exports = ({ production, server, extractCss, coverage, analyze, karma } =
     // @if transpiler.id='babel'
     extensions: ['.js'],
     // @endif
-    modules: [srcDir, nodeModulesDir],
-    // Enforce single aurelia-binding, to avoid v1/v2 duplication due to
-    // out-of-date dependencies on 3rd party aurelia plugins
-    alias: { 'aurelia-binding': path.resolve(__dirname, 'node_modules/aurelia-binding') }
+    modules: [srcDir, nodeModulesDir]
   },
   entry: {
     app: ['aurelia-bootstrapper']


### PR DESCRIPTION
With #970 merged, the `aurelia-binding` alias is no longer required due to `resolve.modules` resolving an absolute path instead of relative.