### PR TITLE
fix(run-webpack.js run-webpack.ts index-webpack.ejs): update run scripts, remove redundant entry in index template

### DIFF
--- a/lib/resources/content/index-webpack.ejs
+++ b/lib/resources/content/index-webpack.ejs
@@ -8,9 +8,5 @@
     <!-- imported CSS are concatenated and added automatically -->
   </head>
   <body aurelia-app="main">
-    <% if (htmlWebpackPlugin.options.metadata.server) { %>
-    <!-- Webpack Dev Server reload -->
-    <script src="/webpack-dev-server.js"></script>
-    <% } %>
   </body>
 </html>

--- a/lib/resources/tasks/run-webpack.js
+++ b/lib/resources/tasks/run-webpack.js
@@ -22,9 +22,15 @@ function runWebpack(done) {
     }
   };
 
+  // Add the webpack-dev-server client to the webpack entry point
+  // The path for the client to use such as `webpack-dev-server/client?http://${opts.host}:${opts.port}/` is not required
+  // The path used is derived from window.location in the browser and output.publicPath in the webpack.config.
   if (project.platform.hmr || CLIOptions.hasFlag('hmr')) {
     config.plugins.push(new webpack.HotModuleReplacementPlugin());
-    config.entry.app.unshift(`webpack-dev-server/client?http://${opts.host}:${opts.port}/`, 'webpack/hot/dev-server');
+    config.entry.app.unshift('webpack-dev-server/client', 'webpack/hot/dev-server');
+  } else {
+    // removed "<script src="/webpack-dev-server.js"></script>" from index.ejs in favour of this method
+    config.entry.app.unshift('webpack-dev-server/client');
   }
 
   const compiler = webpack(config);

--- a/lib/resources/tasks/run-webpack.ts
+++ b/lib/resources/tasks/run-webpack.ts
@@ -23,9 +23,15 @@ function runWebpack(done) {
     https: config.devServer.https
   } as any;
 
+  // Add the webpack-dev-server client to the webpack entry point
+  // The path for the client to use such as `webpack-dev-server/client?http://${opts.host}:${opts.port}/` is not required
+  // The path used is derived from window.location in the browser and output.publicPath in the webpack.config.
   if (project.platform.hmr || CLIOptions.hasFlag('hmr')) {
     config.plugins.push(new webpack.HotModuleReplacementPlugin());
-    config.entry.app.unshift(`webpack-dev-server/client?http://${opts.host}:${opts.port}/`, 'webpack/hot/dev-server');
+    config.entry.app.unshift('webpack-dev-server/client', 'webpack/hot/dev-server');
+  } else {
+    // removed "<script src="/webpack-dev-server.js"></script>" from index.ejs in favour of this method
+    config.entry.app.unshift('webpack-dev-server/client');
   }
 
   const compiler = webpack(config);


### PR DESCRIPTION
fix(run-webpack.js run-webpack.ts index-webpack.ejs): update run scripts, remove redundant entry in index template

Fixes issue where the webpack dev server client is added in both the index.ejs file
and also in 'aurelia_project/tasks/run.ts' when HMR is used.
Improves config by removing unnecessarily specified host:port on the dev server client
This avoids config issues when running behind a reverse proxy

Fixes the following issues:
https://github.com/aurelia/cli/issues/966
https://github.com/aurelia/cli/issues/967