### PR TITLE
fix(webpack): fix broken karma tests in webpack v4

### DIFF
--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -77,7 +77,7 @@
   "karma-sourcemap-loader": "^0.3.7",
   "karma-typescript-preprocessor": "^0.4.0",
   "karma-mocha": "^1.3.0",
-  "karma-webpack": "^3.0.5",
+  "karma-webpack": "^4.0.0-rc.3",
   "minimatch": "^3.0.4",
   "node-sass": "^4.9.3",
   "nps": "^5.9.3",

--- a/lib/resources/content/webpack.config.template.js
+++ b/lib/resources/content/webpack.config.template.js
@@ -43,6 +43,7 @@ module.exports = ({ production, server, extractCss, coverage, analyze, karma } =
     // out-of-date dependencies on 3rd party aurelia plugins
     alias: { 'aurelia-binding': path.resolve(__dirname, 'node_modules/aurelia-binding') }
   },
+  node: { fs: 'empty' }, // Fixes issue: "Error: Can't resolve 'fs'" when running karma tests
   entry: {
     app: ['aurelia-bootstrapper']
   },


### PR DESCRIPTION
Fixes error: "Module not found: Error: Can't resolve 'fs' in"
Fixes issue where tests dont run in webpack v4

Fixes: https://github.com/aurelia/cli/issues/996

