### PR TITLE
fix: avoid early exist of "au new"

### DIFF
--- a/bin/aurelia-cli.js
+++ b/bin/aurelia-cli.js
@@ -13,6 +13,10 @@ Please upgrade to latest Node.js https://nodejs.org`);
 
 process.title = 'aurelia';
 
+const userArgs = process.argv.slice(2);
+const commandName = userArgs[0];
+const commandArgs = userArgs.slice(1);
+
 let originalBaseDir = process.cwd();
 
 resolve('aurelia-cli', {
@@ -20,7 +24,7 @@ resolve('aurelia-cli', {
 }, function(error, projectLocalCli) {
   let cli;
 
-  if (error) {
+  if (commandName === 'new' || error) {
     cli = new (require('../lib/index').CLI);
     cli.options.runningGlobally = true;
   } else {
@@ -29,10 +33,6 @@ resolve('aurelia-cli', {
   }
 
   cli.options.originalBaseDir = originalBaseDir;
-
-  let userArgs = process.argv.slice(2);
-  let commandName = userArgs[0];
-  let commandArgs = userArgs.slice(1);
 
   cli.run(commandName, commandArgs).catch(err => {
     console.log(err);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,22 +17,30 @@ exports.CLI = class {
     this.logger = LogManager.getLogger('CLI');
   }
 
+  // Note: cannot use this.logger.error inside run()
+  // because logger is not configured yet!
+  // this.logger.error prints nothing in run(),
+  // directly use this.ui.log.
   run(cmd, args) {
+    const version = `${this.options.runningGlobally ? 'Global' : 'Local'} aurelia-cli v${require('../package.json').version}`;
+
     if (cmd === '--version' || cmd === '-v') {
-      return this.ui.log(require('../package.json').version);
+      return this.ui.log(version);
     }
 
-    return this._establishProject(this.options)
+    return (cmd === 'new' ? Promise.resolve() : this._establishProject())
       .then(project => {
+        this.ui.log(version);
+
         if (project && this.options.runningLocally) {
           this.project = project;
           this.container.registerInstance(Project, project);
         } else if (project && this.options.runningGlobally) {
-          this.logger.error('The current directory is likely an Aurelia-CLI project, but no local installation of Aurelia-CLI could be found. ' +
+          this.ui.log('The current directory is likely an Aurelia-CLI project, but no local installation of Aurelia-CLI could be found. ' +
             '(Do you need to restore node modules using npm install?)');
           return Promise.resolve();
         } else if (!project && this.options.runningLocally) {
-          this.logger.error('It appears that the Aurelia CLI is running locally from ' + __dirname + '. However, no project directory could be found. ' +
+          this.ui.log('It appears that the Aurelia CLI is running locally from ' + __dirname + '. However, no project directory could be found. ' +
             'The Aurelia CLI has to be installed globally (npm install -g aurelia-cli) and locally (npm install aurelia-cli) in an Aurelia CLI project directory');
           return Promise.resolve();
         }
@@ -101,7 +109,7 @@ exports.CLI = class {
     return this.container.get(require('./commands/help/command'));
   }
 
-  _establishProject(options) {
+  _establishProject() {
     return determineWorkingDirectory(process.cwd())
       .then(dir => dir ? Project.establish(this.ui, dir) : this.ui.log('No Aurelia project found.'));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-cli",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spec/lib/cli.spec.js
+++ b/spec/lib/cli.spec.js
@@ -22,7 +22,7 @@ describe('The cli', () => {
     aureliaProject = 'aurelia_project';
     const fsConfig = {};
     fsConfig[dir] = {};
-    fsConfig['package.json'] = {};
+    fsConfig['package.json'] = '{"version": "1.0.0"}';
     mockfs(fsConfig);
   });
 
@@ -109,16 +109,13 @@ describe('The cli', () => {
     function getVersionSpec(command) {
       return () => {
         beforeEach(() => {
-          mockfs({
-            'package.json': '{"version": "1.0.0"}'
-          });
           spyOn(cli.ui, 'log')
             .and.callFake(() => new Promise(resolve => resolve()));
         });
 
         it('logs the cli version', () => {
           cli.run(command);
-          expect(cli.ui.log).toHaveBeenCalledWith('1.0.0');
+          expect(cli.ui.log).toHaveBeenCalledWith('Local aurelia-cli v1.0.0');
         });
 
         it('returns an empty promise', done => {
@@ -143,7 +140,7 @@ describe('The cli', () => {
 
       cli.run()
         .then(() => {
-          expect(cli._establishProject).toHaveBeenCalledWith(cli.options);
+          expect(cli._establishProject).toHaveBeenCalled();
         }).catch(fail).then(done);
     });
 
@@ -194,12 +191,13 @@ describe('The cli', () => {
       const args = {};
       spyOn(cli, '_establishProject').and.returnValue(Promise.resolve(null)); // no project could be found
       spyOn(cli, 'createCommand').and.returnValue(Promise.resolve(command));
-      const errorSpy = spyOn(cli.logger, 'error');
+      const errorSpy = spyOn(cli.ui, 'log');
 
       cli.run('', args).then(() => {
         expect(command.execute).not.toHaveBeenCalledWith(args);
-        expect(errorSpy).toHaveBeenCalled();
-        expect(errorSpy.calls.first().args[0]).toContain('It appears that the Aurelia CLI is running locally');
+        expect(errorSpy).toHaveBeenCalledTimes(2);
+        expect(errorSpy.calls.first().args[0]).toContain('Local aurelia-cli');
+        expect(errorSpy.calls.argsFor(1)[0]).toContain('It appears that the Aurelia CLI is running locally');
       }).catch(fail).then(done);
     });
   });


### PR DESCRIPTION
Don't try to find local aurelia project when running "au new".
Always use global aurelia-cli to execute "au new".
Log cli version.

closes #977