### PR TITLE
feat(loader): Added Alameda AMD loader to cli flow

### DIFF
--- a/lib/commands/new/buildsystems/cli/loaders/alameda.js
+++ b/lib/commands/new/buildsystems/cli/loaders/alameda.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const ProjectItem = require('../../../../../project-item').ProjectItem;
+
+module.exports = function(project, options) {
+  let model = project.model;
+
+  project.loader = model.loader.id;
+  delete model.loader;
+
+  model.build.loader = {
+    type: 'require',
+    configTarget: 'vendor-bundle.js',
+    includeBundleMetadataInConfig: 'auto',
+    plugins: [
+      { name: 'text', extensions: ['.html', '.css'], stub: true }
+    ]
+  };
+
+  let vendorBundle = model.build.bundles.find(x => x.name === 'vendor-bundle.js');
+  vendorBundle.dependencies.push('text');
+  vendorBundle.prepend.push('node_modules/alameda/alameda.js');
+
+  project.addToClientDependencies(
+    'alameda',
+    'text'
+  );
+
+  if (model.platform.id === 'web') {
+    project.addToContent(ProjectItem.resource('index.html', 'content/require.index.html'));
+  }
+};

--- a/lib/commands/new/new-application.json
+++ b/lib/commands/new/new-application.json
@@ -152,6 +152,11 @@
           "value": "requirejs"
         },
         {
+          "displayName": "CLI's built-in bundler with Alameda",
+          "description": "Alameda is a modern version of RequireJS using promises and native es6 features.",
+          "value": "alameda"
+        },
+        {
           "displayName": "CLI's built-in bundler with SystemJS",
           "description": "SystemJS is Dynamic ES module loader, the most versatile module loader for JavaScript",
           "value": "systemjs"
@@ -168,12 +173,16 @@
           "nextActivity": 611
         },
         {
-          "case": "systemjs",
+          "case": "alameda",
           "nextActivity": 612
         },
         {
-          "case": "webpack",
+          "case": "systemjs",
           "nextActivity": 613
+        },
+        {
+          "case": "webpack",
+          "nextActivity": 614
         }
       ]
     },
@@ -198,6 +207,21 @@
       "nextActivity": 620,
       "state": {
         "loader": {
+          "id": "alameda",
+          "displayName": "Alameda"
+        },
+        "bundler": {
+          "id": "cli",
+          "displayName": "Aurelia-CLI"
+        }
+      }
+    },
+    {
+      "id": 613,
+      "type": "state-assign",
+      "nextActivity": 620,
+      "state": {
+        "loader": {
           "id": "system",
           "displayName": "SystemJS"
         },
@@ -208,7 +232,7 @@
       }
     },
     {
-      "id": 613,
+      "id": 614,
       "type": "state-assign",
       "nextActivity": 615,
       "state": {

--- a/lib/commands/new/new-application.json
+++ b/lib/commands/new/new-application.json
@@ -153,7 +153,7 @@
         },
         {
           "displayName": "CLI's built-in bundler with Alameda",
-          "description": "Alameda is a modern version of RequireJS using promises and native es6 features.",
+          "description": "Alameda is a modern version of RequireJS using promises and native es6 features (modern browsers only).",
           "value": "alameda"
         },
         {

--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -73,7 +73,7 @@
   "karma-babel-preprocessor": "^8.0.0-beta.0",
   "karma-chrome-launcher": "^2.2.0",
   "karma-coverage-istanbul-reporter": "^2.0.4",
-  "karma-jasmine": "^1.1.2",
+  "karma-jasmine": "^2.0.1",
   "karma-sourcemap-loader": "^0.3.7",
   "karma-typescript-preprocessor": "^0.4.0",
   "karma-mocha": "^1.3.0",

--- a/lib/resources/test/alameda.aurelia-karma.js
+++ b/lib/resources/test/alameda.aurelia-karma.js
@@ -57,6 +57,16 @@
       }
       return url;
     };
+
+    const originalDefine = global.define;
+    global.define = function(name, deps, m) {
+      if (typeof name === 'string') {
+        originalDefine('/base/' + root + '/' + name, [name], function (result) { return result; });
+      }
+
+      return originalDefine(name, deps, m);
+    };
+    global.define.amd = originalDefine.amd;
   }
 
   function requireTests() {

--- a/lib/resources/test/alameda.aurelia-karma.js
+++ b/lib/resources/test/alameda.aurelia-karma.js
@@ -1,0 +1,80 @@
+(function(global) {
+  var karma = global.__karma__;
+  var requirejs = global.requirejs
+  var locationPathname = global.location.pathname;
+  var root = 'src';
+  karma.config.args.forEach(function(value, index) {
+    if (value === 'aurelia-root') {
+      root = karma.config.args[index + 1];
+    }
+  });
+
+  if (!karma || !requirejs) {
+    return;
+  }
+
+  function normalizePath(path) {
+    var normalized = []
+    var parts = path
+      .split('?')[0] // cut off GET params, used by noext requirejs plugin
+      .split('/')
+
+    for (var i = 0; i < parts.length; i++) {
+      if (parts[i] === '.') {
+        continue
+      }
+
+      if (parts[i] === '..' && normalized.length && normalized[normalized.length - 1] !== '..') {
+        normalized.pop()
+        continue
+      }
+
+      normalized.push(parts[i])
+    }
+
+    // Use case of testing source code. RequireJS doesn't add .js extension to files asked via sibling selector
+    // If normalized path doesn't include some type of extension, add the .js to it
+    if (normalized.length > 0 && normalized[normalized.length - 1].indexOf('.') < 0) {
+      normalized[normalized.length - 1] = normalized[normalized.length - 1] + '.js'
+    }
+
+    return normalized.join('/')
+  }
+
+  function patchRequireJS(files, originalLoadFn, locationPathname) {
+    var IS_DEBUG = /debug\.html$/.test(locationPathname)
+
+    const origNameToUrl = requirejs.nameToUrl;
+    requirejs.nameToUrl = function karmaNameToUrl(moduleName) {
+      let url = origNameToUrl(moduleName);
+      // Map paths to karma server
+      if (url.indexOf('/base') !== 0) {
+        url = `/base/${url}`;
+      }
+      // Prevent caching by appending file hash as query
+      if (files.hasOwnProperty(url) && !IS_DEBUG) {
+        url = `${url}?${files[url]}`;
+      }
+      return url;
+    };
+  }
+
+  function requireTests() {
+    var TEST_REGEXP = /(spec)\.js$/i;
+    var allTestFiles = [];
+
+    Object.keys(window.__karma__.files).forEach(function(file) {
+      if (TEST_REGEXP.test(file)) {
+        allTestFiles.push(file);
+      }
+    });
+
+    require(['/base/test/unit/setup.js'], function() {
+      require(allTestFiles, window.__karma__.start);
+    });
+  }
+
+  karma.loaded = function() {}; // make it async
+  patchRequireJS(karma.files, requirejs.load, locationPathname);
+  requireTests();
+})(window);


### PR DESCRIPTION
This fixes: #1001 

As alameda and requirejs have the same public api I've just duplicated require loader and require.aurelia-karma.js and adjusted it a bit.
The option was added after requirejs e.g.
1. Webpack
2. RequireJS
3. Alameda
4. SystemJS

As alameda has no internal function `load` we could override, I've used the nameToUrl function which serves the same use case.
I've tested application run and test execution for all loaders with jasmine and one with jest.
Also I could not find a test to extend for this use case and did not add any.