### PR TITLE
fix(bundler): fix stubbing on core Nodejs module "stream"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-cli",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "opn": "^5.4.0",
     "preprocess": "^3.1.0",
     "querystring-es3": "1.0.0-0",
+    "readable-stream": "^2.3.6",
     "rfc6902": "^3.0.1",
     "semver": "^5.5.1",
     "terser": "^3.10.0",


### PR DESCRIPTION
Pin readable-stream to v2 which is required by stream-browserify.
This enforces auto-tracer to use readable-stream v2 even when user's app has v3 installed. Auto-tracer always resolves module in cli's node_modules folder, before trying user's app's node_modules folder.