### PR TITLE
fix(bundler): fix plugin prefix/subfix regex match

### DIFF
--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -253,8 +253,24 @@ exports.BundledSource = class {
     this.requiresTransform = false;
     if (!deps || deps.length === 0) return;
 
-    let moduleIds = Array.from(new Set(deps)) // unique
-      .map(stripPluginPrefixOrSubfix)
+    let needed = new Set();
+
+    Array.from(new Set(deps)) // unique
+      .map(d => {
+        const loc = d.indexOf('!');
+        if (loc < 1 || loc === d.length - 1) return d;
+
+        let pluginName = d.slice(0, loc);
+        let dep = d.slice(loc + 1);
+
+        if (loaderType === 'system') {
+          [pluginName, dep] = [dep, pluginName];
+        }
+        if (pluginName !== 'text' && pluginName !== 'json') {
+          needed.add(pluginName);
+        }
+        return dep;
+      })
       .filter(d => {
         // any dep requested by a npm package file
         if (this.dependencyInclusion) return true;
@@ -265,17 +281,17 @@ exports.BundledSource = class {
         return Utils.couldMissGulpPreprocess(d);
       })
       .map(d => absoluteModuleId(moduleId, d))
-      .filter(d => {
+      .forEach(d => {
         // ignore false replacment
         if (browserReplacement && browserReplacement.hasOwnProperty(d)) {
           if (browserReplacement[d] === false) {
-            return false;
+            return;
           }
         }
-        return true;
+        needed.add(d);
       });
 
-    return moduleIds;
+    return Array.from(needed);
   }
 };
 
@@ -294,20 +310,6 @@ function possibleShortcut(moduleId, paths) {
       };
     }
   }
-}
-
-function stripPluginPrefixOrSubfix(moduleId) {
-  const hasPrefix = moduleId.match(/^\w+\!(.+)$/);
-  if (hasPrefix) {
-    return hasPrefix[1];
-  }
-
-  const hasSubfix = moduleId.match(/^(.+)\!\w+$/);
-  if (hasSubfix) {
-    return hasSubfix[1];
-  }
-
-  return moduleId;
 }
 
 function absoluteModuleId(baseId, moduleId) {

--- a/spec/lib/build/bundled-source.spec.js
+++ b/spec/lib/build/bundled-source.spec.js
@@ -104,7 +104,7 @@ describe('the BundledSource module', () => {
   it('transforms local js file', () => {
     let file = {
       path: path.resolve(cwd, 'src/foo/bar/loo.js'),
-      contents: "define(['./a', 'lo/rem', 'text!./loo.yaml', 'text!foo.html'], function(a,r){});"
+      contents: "define(['./a', 'lo/rem', 'text!./loo.yaml', 'text!foo.html', 'some/plugin!bar.html'], function(a,r){});"
     };
 
     let bs = new BundledSource(bundler, file);
@@ -120,9 +120,9 @@ describe('the BundledSource module', () => {
     bs._getUseCache = () => undefined;
 
     let deps = bs.transform();
-    expect(deps).toEqual(['lo/rem', 'foo/bar/loo.yaml', 'foo.html']); // relative dep is ignored
+    expect(deps.sort()).toEqual(['bar.html', 'foo.html', 'foo/bar/loo.yaml', 'lo/rem', 'some/plugin']); // relative dep is ignored
     expect(bs.requiresTransform).toBe(false);
-    expect(bs.contents).toBe("define('foo/bar/loo',['./a', 'lo/rem', 'text!./loo.yaml', 'text!foo.html'], function(a,r){});");
+    expect(bs.contents).toBe("define('foo/bar/loo',['./a', 'lo/rem', 'text!./loo.yaml', 'text!foo.html', 'some/plugin!bar.html'], function(a,r){});");
     expect(bundler.configTargetBundle.addAlias).toHaveBeenCalledWith('b8/loo', 'foo/bar/loo');
   });
 


### PR DESCRIPTION
Fixed a bug when tracing a dep with name spaced plugin like "@au/plugin!./foo.html", it also traces module "@au/plugin".