### PR TITLE
fix(webpack): correctly exclude spec/test files from coverage report

### DIFF
--- a/lib/resources/content/webpack.config.template.js
+++ b/lib/resources/content/webpack.config.template.js
@@ -266,7 +266,7 @@ module.exports = ({ production, server, extractCss, coverage, analyze, karma } =
       // @if transpiler.id='typescript'
       ...when(coverage, {
         test: /\.[jt]s$/i, loader: 'istanbul-instrumenter-loader',
-        include: srcDir, exclude: [/\.{spec,test}\.[jt]s$/i],
+        include: srcDir, exclude: [/\.(spec|test)\.[jt]s$/i],
         enforce: 'post', options: { esModules: true },
       })
       // @endif


### PR DESCRIPTION
The string {spec,test} is not a valid regex and thus didn't match filenames containing spec or test, as was clearly intended.
This caused coverage reports to include these files.

The new regex now correctly excludes these test files.