### PR TITLE
WIP feat(test): switch from aurelia-pal-nodejs to aurelia-pal-browser for jest setup

### DIFF
--- a/lib/commands/new/buildsystems/general/unit-test-runners/jest.js
+++ b/lib/commands/new/buildsystems/general/unit-test-runners/jest.js
@@ -17,7 +17,7 @@ module.exports = function(project) {
     'jest-cli',
     'plugin-error',
     'aurelia-loader-nodejs',
-    'aurelia-pal-nodejs'
+    'jest-environment-jsdom-thirteen'
   ).addNPMScript('test', 'au jest');
 
   if (project.model.transpiler.id === 'babel') {
@@ -46,7 +46,7 @@ module.exports = function(project) {
       setupFiles: [
         '<rootDir>/test/jest-pretest.js'
       ],
-      testEnvironment: 'node',
+      testEnvironment: 'jest-environment-jsdom-thirteen',
       collectCoverage: true,
       collectCoverageFrom: [
         'src/**/*.js',
@@ -89,7 +89,7 @@ module.exports = function(project) {
       setupFiles: [
         '<rootDir>/test/jest-pretest.ts'
       ],
-      testEnvironment: 'node',
+      testEnvironment: 'jest-environment-jsdom-thirteen',
       collectCoverage: true,
       collectCoverageFrom: [
         'src/**/*.{js,ts}',

--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -66,6 +66,7 @@
   "jest": "^23.6.0",
   "jest-jasmine2": "^23.6.0",
   "jest-cli": "^23.6.0",
+  "jest-environment-jsdom-thirteen": "^0.0.2",
   "jest-matchers": "^20.0.3",
   "json-loader": "^0.5.7",
   "html-loader": "^0.5.5",

--- a/lib/resources/test/jest-pretest.js
+++ b/lib/resources/test/jest-pretest.js
@@ -1,6 +1,6 @@
 import 'aurelia-polyfills';
 import {Options} from 'aurelia-loader-nodejs';
-import {globalize} from 'aurelia-pal-nodejs';
-import * as path from 'path';
+import {initialize} from 'aurelia-pal-browser';
+import path from 'path';
 Options.relativeToDir = path.join(__dirname, 'unit');
-globalize();
+initialize();

--- a/lib/resources/test/jest-pretest.ts
+++ b/lib/resources/test/jest-pretest.ts
@@ -1,6 +1,6 @@
 import 'aurelia-polyfills';
 import {Options} from 'aurelia-loader-nodejs';
-import {globalize} from 'aurelia-pal-nodejs';
+import {initialize} from 'aurelia-pal-browser';
 import * as path from 'path';
 Options.relativeToDir = path.join(__dirname, 'unit');
-globalize();
+initialize();


### PR DESCRIPTION
jest by default does simulate browser environment. It's unnecessary to use pal-nodejs (which brings in jsdom ~~but doesn't pollute global vars~~). Using pal-browser with default jest simulation has extra benefit: be more compatible with 3rd party libs which expects global vars.

cloese #1018