### PR TITLE
fix(bundler): tolerant js with missing ending semicolon

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -243,7 +243,7 @@ exports.Bundle = class {
 
     return work.then(() => {
       const Concat = require('concat-with-sourcemaps');
-      let concat = new Concat(true, this.config.name, os.EOL);
+      let concat = new Concat(true, this.config.name, ';' + os.EOL);
       const generateHashedPath = require('./utils').generateHashedPath;
       const generateHash = require('./utils').generateHash;
       let needsSourceMap = false;


### PR DESCRIPTION
Some js lib (like blueimp-md5) doesn't have an ending semicolon. Existing bundler results in syntax error.

closes #1021