### PR TITLE
feat(find-deps): add build tracing for import elements

### DIFF
--- a/lib/build/find-deps.js
+++ b/lib/build/find-deps.js
@@ -266,7 +266,7 @@ exports.findHtmlDeps = function(filename, contents, loaderType = 'require') {
   let parser = new htmlparser.Parser({
     onopentag: function(name, attrs) {
       // <require from="dep"></require>
-      if (name === 'require' && attrs.from) {
+      if ((name === 'require' || name === 'import') && attrs.from) {
         add(auDep(attrs.from, loaderType));
       // <compose view-model="vm" view="view"></compose>
       // <any as-element="compose" view-model="vm" view="view"></any>

--- a/spec/lib/build/find-deps.spec.js
+++ b/spec/lib/build/find-deps.spec.js
@@ -26,6 +26,7 @@ let html = `
   <template>
     <require from="a/b"></require>
     <require from="./c.html"></require>
+    <import from="./from-import.html"></import>
     <div>
       <p>
         <REQUIRE from="d/e.css"></REQUIRE>
@@ -43,8 +44,8 @@ let html = `
     <unknown as-element="router-view" layout-view-model="lvm2" layout-view="lv2"></unknown>
   </template>
 `;
-let htmlDeps = ['a/b', 'lv1', 'lv2', 'lvm2', 'text!./c.html', 'text!d/e.css', 'v2', 'vm1', 'vm2'];
-let htmlDepsSystemJS = ['./c.html!text', 'a/b', 'd/e.css!text', 'lv1', 'lv2', 'lvm2', 'v2', 'vm1', 'vm2'];
+let htmlDeps = ['a/b', 'lv1', 'lv2', 'lvm2', 'text!./c.html', 'text!./from-import.html', 'text!d/e.css', 'v2', 'vm1', 'vm2'];
+let htmlDepsSystemJS = ['./c.html!text', './from-import.html!text', 'a/b', 'd/e.css!text', 'lv1', 'lv2', 'lvm2', 'v2', 'vm1', 'vm2'];
 
 let css = `
 @import 'other.css';


### PR DESCRIPTION
This PR extends the build tracing to not only bundle deps from `<require>` elements but also from `<import>` elements in preparation for vNext's support for both options.

Partial work related to https://github.com/aurelia/aurelia/issues/116