### PR TITLE
fix(fs.existsSync): change existsSync to correctly handle thrown error

### DIFF
--- a/lib/file-system.js
+++ b/lib/file-system.js
@@ -25,7 +25,11 @@ exports.stat = function(path) {
 };
 
 exports.existsSync = function(path) {
-  return fs.existsSync(path);
+  try {
+    return fs.existsSync(path);
+  } catch {
+    return false;
+  }
 };
 
 exports.mkdir = function(path) {

--- a/lib/file-system.js
+++ b/lib/file-system.js
@@ -27,7 +27,7 @@ exports.stat = function(path) {
 exports.existsSync = function(path) {
   try {
     return fs.existsSync(path);
-  } catch {
+  } catch (err) {
     return false;
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-cli",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
existsSync throwns an error while it should return a boolean.
Wrapped function in a try/catch to surpress the error.

Partial fix for #1027