### PR TITLE
fix(jest): avoid aurelia-bindings v1+v2 conflict

### DIFF
--- a/lib/commands/new/buildsystems/general/unit-test-runners/jest.js
+++ b/lib/commands/new/buildsystems/general/unit-test-runners/jest.js
@@ -27,6 +27,10 @@ module.exports = function(project) {
     );
 
     project.package.jest = {
+      moduleNameMapper: {
+        // avoid aurelia-bindings v1+v2 conflict
+        '^aurelia-binding$': '<rootDir>/node_modules/aurelia-binding'
+      },
       modulePaths: [
         '<rootDir>/src',
         '<rootDir>/node_modules'
@@ -65,6 +69,10 @@ module.exports = function(project) {
     );
 
     project.package.jest = {
+      moduleNameMapper: {
+        // avoid aurelia-bindings v1+v2 conflict
+        '^aurelia-binding$': '<rootDir>/node_modules/aurelia-binding'
+      },
       modulePaths: [
         '<rootDir>/src',
         '<rootDir>/node_modules'


### PR DESCRIPTION
This is a similar fix to jest as #906 to webpack. Thank @ariovistus to point this out at https://discourse.aurelia.io/t/jest-cannot-find-module/2217/3