### PR TITLE
fix(bundler): enable tracing @babel/polyfill

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -189,7 +189,8 @@ exports.Bundle = class {
 
     if (loaderOptions.configTarget === this.config.name) {
       work = work.then(() => {
-        files.push({ contents: '_aureliaConfigureModuleLoader();'});
+        // create global var "global" for compatibility with nodejs
+        files.push({ contents: 'var global = this; _aureliaConfigureModuleLoader();'});
       });
     }
 

--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -216,7 +216,10 @@ exports.BundledSource = class {
         let contents;
         // forceCjsWrap bypasses a r.js parse bug.
         // See lib/amodro-trace/read/cjs.js for more info.
-        let forceCjsWrap = !!modulePath.match(/(\/|\\)(cjs|commonjs)(\/|\\)/i);
+        let forceCjsWrap = !!modulePath.match(/(\/|\\)(cjs|commonjs)(\/|\\)/i) ||
+          // core-js uses "var define = ..." everywhere, we need to force cjs
+          // before we can switch to dumberjs bundler
+          (desc && desc.name === 'core-js');
 
         try {
           contents = cjsTransform(modulePath, this.contents, forceCjsWrap);

--- a/lib/commands/new/buildsystems/cli/index.js
+++ b/lib/commands/new/buildsystems/cli/index.js
@@ -63,8 +63,7 @@ module.exports = function(project, options) {
           {
             'path': 'node_modules/aurelia-cli/lib/resources/scripts/configure-bluebird.js',
             'env': 'dev'
-          },
-          'node_modules/@babel/polyfill/browser.js'
+          }
         ],
         dependencies: [
           // only needs packages not explicitly depend

--- a/lib/resources/src/main-cli.js
+++ b/lib/resources/src/main-cli.js
@@ -1,3 +1,4 @@
+import '@babel/polyfill';
 import environment from './environment';
 
 export function configure(aurelia) {

--- a/lib/resources/src/main-cli.template.js
+++ b/lib/resources/src/main-cli.template.js
@@ -1,3 +1,4 @@
+import '@babel/polyfill';
 import environment from './environment';
 // @if features.bootstrap='bootstrap'
 import 'bootstrap';


### PR DESCRIPTION
A simple global var "global" is created before load all AMD modules. This is a practical way to support nodejs global var "global". In future we will build on top of dumberjs to properly support nodejs global vars "global", "process", and "Buffer" (the last two are still not supported transparently in aurelia-cli bundler).

core-js uses "var define = ..." everywhere, we need to force cjs wrap before we can switch to dumberjs bundler.

With this fix, `@babel/polyfill` now works as an AMD module.