### PR TITLE
fix(bundler): isolate cache between systemjs and requirejs apps

### DIFF
--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -201,6 +201,7 @@ exports.BundledSource = class {
         // among different apps.
         const key = [
           moduleId,
+          loaderType,
           JSON.stringify(context),
           JSON.stringify(opts),
           this.contents // contents here is after gulp transpile task


### PR DESCRIPTION
Previously, rarely, but when user has both systemjs app and requirejs app, the bundler could use a wrong cache.