### PR TITLE
fix(cypress task): Return error when tests fail

### DIFF
--- a/lib/resources/tasks/cypress.js
+++ b/lib/resources/tasks/cypress.js
@@ -2,9 +2,12 @@ import cypress from 'cypress';
 import { CLIOptions } from 'aurelia-cli';
 import config from '../../cypress.config';
 
-export default () => {
+export default (resolve) => {
   if (CLIOptions.hasFlag('run')) {
-    cypress.run(config);
+    cypress
+      .run(config)
+      .then(results => (results.totalFailed === 0 ? resolve() : resolve('Run failed!')))
+      .catch(resolve);
   } else {
     cypress.open(config);
   }

--- a/lib/resources/tasks/cypress.js
+++ b/lib/resources/tasks/cypress.js
@@ -2,12 +2,12 @@ import cypress from 'cypress';
 import { CLIOptions } from 'aurelia-cli';
 import config from '../../cypress.config';
 
-export default (resolve) => {
+export default (cb) => {
   if (CLIOptions.hasFlag('run')) {
     cypress
       .run(config)
-      .then(results => (results.totalFailed === 0 ? resolve() : resolve('Run failed!')))
-      .catch(resolve);
+      .then(results => (results.totalFailed === 0 ? cb() : cb('Run failed!')))
+      .catch(cb);
   } else {
     cypress.open(config);
   }

--- a/lib/resources/tasks/cypress.ts
+++ b/lib/resources/tasks/cypress.ts
@@ -2,12 +2,12 @@ import * as cypress from 'cypress';
 import { CLIOptions } from 'aurelia-cli';
 import * as config from '../../cypress.config';
 
-export default (resolve) => {
+export default (cb) => {
   if (CLIOptions.hasFlag('run')) {
     cypress
       .run(config)
-      .then(results => (results.totalFailed === 0 ? resolve() : resolve('Run failed!')))
-      .catch(resolve);
+      .then(results => (results.totalFailed === 0 ? cb() : cb('Run failed!')))
+      .catch(cb);
   } else {
     cypress.open(config);
   }

--- a/lib/resources/tasks/cypress.ts
+++ b/lib/resources/tasks/cypress.ts
@@ -2,9 +2,12 @@ import * as cypress from 'cypress';
 import { CLIOptions } from 'aurelia-cli';
 import * as config from '../../cypress.config';
 
-export default () => {
+export default (resolve) => {
   if (CLIOptions.hasFlag('run')) {
-    cypress.run(config);
+    cypress
+      .run(config)
+      .then(results => (results.totalFailed === 0 ? resolve() : resolve('Run failed!')))
+      .catch(resolve);
   } else {
     cypress.open(config);
   }


### PR DESCRIPTION
Make au cypress --run emit error when a test failed to allow a build process/step to fail.

Closes #1057