### PR TITLE
fix(bundler): skip deps cleanup (remove .js) for UMD file

### DIFF
--- a/lib/build/amodro-trace/write/replace.js
+++ b/lib/build/amodro-trace/write/replace.js
@@ -11,6 +11,8 @@ const astMatcher = require('../../ast-matcher').astMatcher;
 // it is definitely a named AMD module at this stage
 var amdDep = astMatcher('define(__str, [__anl_deps], __any)');
 var cjsDep = astMatcher('require(__any_dep)');
+var isUMD = astMatcher('typeof define === "function" && define.amd');
+var isUMD2 = astMatcher('typeof define == "function" && define.amd');
 
 module.exports = function stubs(options) {
   options = options || {};
@@ -47,6 +49,12 @@ module.exports = function stubs(options) {
 
     // need node location
     const parsed = esprima.parse(contents, {range: true});
+
+    if (isUMD(parsed) || isUMD2(parsed)) {
+      // Skip lib in umd format, because browersify umd build could
+      // use require('./file.js') which we should not strip .js
+      return contents;
+    }
 
     const amdMatch = amdDep(parsed);
     if (amdMatch) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6931,7 +6931,7 @@
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
         "through": "2"
@@ -6948,7 +6948,7 @@
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "dev": true,
       "requires": {
         "through2": "^2.0.2"


### PR DESCRIPTION
When the UMD file was prepared by browserify, those `require('./a.js')` were matched by a hash map like `{'./a.js':1}`. We cannot clean them up to `require('./a')`, as it will end up with missing entry.

closes #1054