### PR TITLE
fix(sourcemaps): strip path from bundle sourcemap

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -404,7 +404,7 @@ exports.Bundle = class {
           .setProperty('sourceRoot', mapSourceRoot)
           .toJSON();
 
-        contents += os.EOL + '//# sourceMappingURL=' + mapFileName;
+        contents += os.EOL + '//# sourceMappingURL=' +  path.basename(mapFileName);
       }
 
       return fs.writeFile(path.posix.join(platform.output, bundleFileName), contents).then(() => {


### PR DESCRIPTION
having bundle name specified with path in aurelia.json
bundler produces a sourcemap comment with path included
which leads to sourcemap not being loaded by browser
