### PR TITLE
fix(bundler): improve compatibility with legacy libs that depends on jquery or momentjs

### DIFF
--- a/lib/build/amodro-trace/write/defines.js
+++ b/lib/build/amodro-trace/write/defines.js
@@ -29,6 +29,13 @@ function defines(options) {
         config = context.config,
         packageName = context.pkgsMainMap[moduleName];
 
+    if (packageName === 'moment') {
+      // Expose moment to global var to improve compatibility with some legacy libs.
+      // It also load momentjs up immediately.
+      _contents = _contents.replace(/\bdefine\((\w+)\)/, (match, factoryName) =>
+        `(function(){var m=${factoryName}();if(typeof moment === 'undefined'){window.moment=m;} define(function(){return m;})})()`
+      );
+    }
 
     function onFound(info) {
       if (info.foundId) {

--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -170,7 +170,24 @@ exports.Bundle = class {
     };
 
     bundleFiles.forEach(visit);
-    return sorted;
+
+    // Special treatment for jquery and moment, put them in front of everything else,
+    // so that jquery and moment can create global vars as early as possible.
+    // This improves compatibility with some legacy jquery plugins.
+    // Note as of momentjs version 2.10.0, momentjs no longer exports global object
+    // in AMD module environment. There is special code in lib/build/amodro-trace/write/defines.js
+    // to bring up global var "moment".
+    const special = [];
+    while (true) { // eslint-disable-line no-constant-condition
+      const idx = sorted.findIndex(f => f.dependencyInclusion && (
+        f.dependencyInclusion.description.name === 'jquery' ||
+        f.dependencyInclusion.description.name === 'moment'));
+
+      if (idx === -1) break;
+      special.push(...sorted.splice(idx, 1));
+    }
+
+    return [...special, ...sorted];
   }
 
   write(platform) {


### PR DESCRIPTION
Special treatment for jquery and moment, put them in front of everything else, so that jquery and moment can create global vars as early as possible. This improves compatibility with some legacy jquery plugins.
Note as of momentjs version 2.10.0, momentjs no longer exports global object in AMD module environment. There is special code in lib/build/amodro-trace/write/defines.js to bring up global var "moment".