### PR TITLE
fix(new-application): add missing dep clean-webpack-plugin to dotnet-core+webpack app

### DIFF
--- a/lib/workflow/questionnaire.js
+++ b/lib/workflow/questionnaire.js
@@ -197,7 +197,7 @@ exports.askScaffold = {
   }, {
     value: 'scaffold-navigation',
     message: 'Navigation App',
-    hint: 'Add a router and some sample routes, Bootstrap v4 and Font Awesome v4.'
+    hint: 'Add a router and some sample routes, Bootstrap v3 and Font Awesome v4.'
   }]
 };
 

--- a/skeleton/dotnet-core/package.json__if_webpack
+++ b/skeleton/dotnet-core/package.json__if_webpack
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "clean-webpack-plugin": ""
+  }
+}


### PR DESCRIPTION
closes #1072
cc @brandonseydel, it might impact your project.

Our release-check task has not turned on tests on `dotnet run`. We need to add that coverage in future.

Tested. @EisenbergEffect it's safe to merge.