### PR TITLE
fix(skeleton): fix Promise polyfill on IE

### DIFF
--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -29,7 +29,6 @@
   "clean-webpack-plugin": "^1.0.1",
   "connect-history-api-fallback": "^1.6.0",
   "copy-webpack-plugin": "^5.0.0",
-  "core-js": "^3.0.0",
   "cross-env": "^5.2.0",
   "cssnano": "^4.1.10",
   "css-loader": "^1.0.0",

--- a/lib/dependencies.json
+++ b/lib/dependencies.json
@@ -82,6 +82,7 @@
   "opn": "^5.4.0",
   "postcss-loader": "^3.0.0",
   "postcss-url": "^8.0.0",
+  "promise-polyfill": "^8.1.0",
   "protractor": "^5.4.2",
   "regenerator-runtime": "0.13.2",
   "requirejs": "^2.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-cli",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/skeleton/cli-bundler/aurelia_project/aurelia.json
+++ b/skeleton/cli-bundler/aurelia_project/aurelia.json
@@ -144,6 +144,7 @@
       {
         "name": "vendor-bundle.js",
         "prepend": [
+          "node_modules/promise-polyfill/dist/polyfill.min.js",
           // @if feat.requirejs
           "node_modules/requirejs/require.js"
           // @endif

--- a/skeleton/common/package.json
+++ b/skeleton/common/package.json
@@ -25,6 +25,7 @@
     "minimatch": "",
     "through2": "",
     "vinyl-fs": "",
+    "promise-polyfill": "",
 
     // @if feat.babel
     "regenerator-runtime": "",

--- a/skeleton/common/package.json
+++ b/skeleton/common/package.json
@@ -21,7 +21,6 @@
     "aurelia-cli": "",
     "aurelia-testing": "",
     "aurelia-tools": "",
-    "core-js": "",
     "gulp": "",
     "minimatch": "",
     "through2": "",

--- a/skeleton/plugin/dev-app/main.ext
+++ b/skeleton/plugin/dev-app/main.ext
@@ -1,5 +1,6 @@
-import 'core-js/stable';
 // @if feat.babel
+// regenerator-runtime is to support async/await syntax in ESNext.
+// If you don't use async/await, you can remove regenerator-runtime.
 import 'regenerator-runtime/runtime';
 // @endif
 // @if feat.typescript

--- a/skeleton/scaffold-minimum/src/main.ext
+++ b/skeleton/scaffold-minimum/src/main.ext
@@ -1,5 +1,6 @@
-import 'core-js/stable';
 // @if feat.babel
+// regenerator-runtime is to support async/await syntax in ESNext.
+// If you don't use async/await, you can remove regenerator-runtime.
 import 'regenerator-runtime/runtime';
 // @endif
 // @if feat.typescript

--- a/skeleton/scaffold-navigation/src/main.ext
+++ b/skeleton/scaffold-navigation/src/main.ext
@@ -1,5 +1,6 @@
-import 'core-js/stable';
 // @if feat.babel
+// regenerator-runtime is to support async/await syntax in ESNext.
+// If you don't use async/await, you can remove regenerator-runtime.
 import 'regenerator-runtime/runtime';
 // @endif
 import 'bootstrap';

--- a/skeleton/webpack/webpack.config.js
+++ b/skeleton/webpack/webpack.config.js
@@ -287,6 +287,7 @@ module.exports = ({ production, server, extractCss, coverage, analyze, karma } =
       $: 'jquery',
       jQuery: 'jquery',
     // @endif
+      'Promise': ['promise-polyfill', 'default']
     }),
     new ModuleDependenciesPlugin({
       'aurelia-testing': ['./compile-spy', './view-spy']


### PR DESCRIPTION
Removed core-js as the import is too late for IE11.
Load promise-polyfill before loading aurelia-bootstrapper. The polyfill can be removed if user don't need to support IE.

closes #1079