### PR TITLE
fix(ts + jest + cypress): Add missing type

### DIFF
--- a/skeleton/cypress/package.json
+++ b/skeleton/cypress/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     // @if feat.typescript
+    "@types/mocha": "",
     "@cypress/webpack-preprocessor": "",
     "webpack": "",
     "ts-loader": "",


### PR DESCRIPTION
Add @types/mocha to fix compilation when using ts + jest + cypress.

Closes #1099