### PR TITLE
feat(cli): Warn the user for providing multiple arguments with aurelia new command

### DIFF
--- a/bin/aurelia-cli.js
+++ b/bin/aurelia-cli.js
@@ -25,7 +25,7 @@ resolve('aurelia-cli', {
   let cli;
 
   if (commandName === 'new' || error) {
-    const args = commandArgs.filter(item => !item.includes('-'));
+    const args = commandArgs.filter(item => !item.charAt(0).includes('-'));
     if (args.length > 1) {
     	console.log();
     	console.log(' Kindly provide only one argument as the <project-name>');

--- a/bin/aurelia-cli.js
+++ b/bin/aurelia-cli.js
@@ -25,12 +25,6 @@ resolve('aurelia-cli', {
   let cli;
 
   if (commandName === 'new' || error) {
-    const args = commandArgs.filter(item => !item.charAt(0).includes('-'));
-    if (args.length > 1) {
-    	console.log();
-    	console.log(' Kindly provide only one argument as the <project-name>');
-    	process.exit(1);
-    }	
     cli = new (require('../lib/index').CLI);
     cli.options.runningGlobally = true;
   } else {

--- a/bin/aurelia-cli.js
+++ b/bin/aurelia-cli.js
@@ -25,6 +25,12 @@ resolve('aurelia-cli', {
   let cli;
 
   if (commandName === 'new' || error) {
+    const args = commandArgs.filter(item => !item.includes('-'));
+    if (args.length > 1) {
+    	console.log();
+    	console.log(' Kindly provide only one argument as the <project-name>');
+    	process.exit(1);
+    }	
     cli = new (require('../lib/index').CLI);
     cli.options.runningGlobally = true;
   } else {

--- a/lib/commands/new/command.js
+++ b/lib/commands/new/command.js
@@ -29,6 +29,14 @@ module.exports = class {
     // -u
     this.unattended = this.options.hasFlag('unattended');
 
+    // Validate arguments provided as the <project-name>
+    const userArgs = this.options.args.filter(item => !item.startsWith('-'));
+    if (userArgs.length > 1) {
+    	console.log();
+    	console.log(' Kindly provide only one argument as the <project-name>');
+    	process.exit(1);
+    }
+
     // Preselect features
     // In unattended mode, these overwrite default-esnext selections.
     // In interactive mode, some questions will be skipped because they are
@@ -228,4 +236,3 @@ async function minFeatures(features, plugin) {
   }
   return mustHave;
 }
-

--- a/lib/commands/new/command.js
+++ b/lib/commands/new/command.js
@@ -29,14 +29,6 @@ module.exports = class {
     // -u
     this.unattended = this.options.hasFlag('unattended');
 
-    // Validate arguments provided as the <project-name>
-    const userArgs = this.options.args.filter(item => !item.startsWith('-'));
-    if (userArgs.length > 1) {
-    	console.log();
-    	console.log(' Kindly provide only one argument as the <project-name>');
-    	process.exit(1);
-    }
-
     // Preselect features
     // In unattended mode, these overwrite default-esnext selections.
     // In interactive mode, some questions will be skipped because they are
@@ -64,6 +56,14 @@ module.exports = class {
       const dir = this.options.originalBaseDir;
       projectName = dir.split(/\\|\//).pop();
     } else if (args[0] && !args[0].startsWith('-')) {
+      
+      // Validate arguments provided as the <project-name>
+      if (args.length > 1) {
+        console.log();
+        console.log(' Kindly provide only one argument as the <project-name>');
+        process.exit(1);
+      }
+
       projectName = args[0];
     }
 

--- a/lib/commands/new/command.js
+++ b/lib/commands/new/command.js
@@ -56,7 +56,6 @@ module.exports = class {
       const dir = this.options.originalBaseDir;
       projectName = dir.split(/\\|\//).pop();
     } else if (args[0] && !args[0].startsWith('-')) {
-      
       // Validate arguments provided as the <project-name>
       if (args.length > 1) {
         console.log();

--- a/spec/lib/commands/config/new.spec.js
+++ b/spec/lib/commands/config/new.spec.js
@@ -1,0 +1,58 @@
+describe('The new command', () => {
+  const Command = require('../../../../lib/commands/new/command');
+
+  const specs = [
+    {
+      input: ['foo', 'bar'],
+      isValid: false
+    },
+    {
+      input: ['foo'],
+      isValid: true
+    },
+    {
+      input: ['foo-bar'],
+      isValid: true
+    },
+    {
+      input: ['foo', 'foo-bar'],
+      isValid: false
+    },
+    {
+      input: ['foo', '-foo-bar'],
+      isValid: false
+    }
+  ];
+
+  for (const spec of specs) {
+    it(`validates ${spec.input.join(' ')} as isValid=${spec.isValid}`, () => {
+      const stubUI = {
+        displayLogo() { }
+      };
+      const stubOptions = {
+        hasFlag() { return false; },
+        getFlagValue() { return ''; }
+      };
+
+      let message;
+      const originalLog = console.log;
+      const logSpy = (msg) => {
+        message = msg;
+        console.log(msg);
+      };
+      console.log = logSpy;
+
+      const sut = new Command(stubUI, stubOptions);
+
+      sut.execute(['foo', 'bar']);
+
+      console.log = originalLog;
+
+      if (spec.isValid) {
+        expect(message).toBe('...');
+      } else {
+        expect(message).toBe(' Kindly provide only one argument as the <project-name>');
+      }
+    });
+  }
+});


### PR DESCRIPTION
As per now `aurelia new <project-name> arg` goes ahead without any sort of warnings being thrown. 
Made it such that the user is warned if he does so.

This is how it looks like:-
![Screenshot from 2019-05-17 08-30-26](https://user-images.githubusercontent.com/25279263/57900339-141a6f80-787e-11e9-94bf-72fd713ffba7.png)
