### PR TITLE
fix(skeleton): fix missing .gitignore file in aurelia-cli npm package

### DIFF
--- a/skeleton/common/.gitignore__append-if-exists
+++ b/skeleton/common/.gitignore__append-if-exists
@@ -1,3 +1,4 @@
+
 # You may want to customise this file depending on your Operating System
 # and the editor that you use.
 #


### PR DESCRIPTION
When building npm package, `npm pack` ignored skeleton/common/.gitignore file because it by default ignores any .gitignore file. Rename .gitignore to .gitignore__append-if-exists is the cheapest way to bypass npm's default behaviour. The alternative fix is to use "files" field in package.json, but that's too verbose.

closes #1102