### PR TITLE
feat(plugin, build-plugin): Add option to process aliases in templates

### DIFF
--- a/skeleton/cli-bundler/aurelia_project/tasks/process-markup.ext
+++ b/skeleton/cli-bundler/aurelia_project/tasks/process-markup.ext
@@ -17,6 +17,9 @@ import * as plumber from 'gulp-plumber';
 import * as notify from 'gulp-notify';
 // @endif
 // @endif
+// @if feat.plugin
+import { processMarkupAliases } from './process-markup-aliases';
+// @endif
 
 export default function processMarkup() {
   return gulp.src(project.markupProcessor.source, {sourcemaps: true, since: gulp.lastRun(processMarkup)})
@@ -41,26 +44,34 @@ export default function processMarkup() {
 }
 
 // @if feat.plugin
-export function pluginMarkup(dest) {
+export function pluginMarkup(dest, runProcessMarkupAliases = false, verbose = false) {
   return function processPluginMarkup() {
-    return gulp.src(project.plugin.source.html)
-      // @if feat['htmlmin-min'] || feat['htmlmin-max']
-      .pipe(htmlmin({
-          // @if feat['htmlmin-max']
-          collapseInlineTagWhitespace: true,
-          collapseBooleanAttributes: true,
-          removeAttributeQuotes: true,
-          removeScriptTypeAttributes: true,
-          removeStyleLinkTypeAttributes: true,
-          // @endif
-          removeComments: true,
-          collapseWhitespace: true,
-          minifyCSS: true,
-          minifyJS: true,
-          ignoreCustomFragments: [/\${.*?}/g] // ignore interpolation expressions
-      }))
-      // @endif
-      .pipe(gulp.dest(dest));
+    let stream = gulp.src(project.plugin.source.html);
+
+        if (runProcessMarkupAliases) {
+            stream = stream.pipe(processMarkupAliases(verbose));
+        }
+
+        stream = stream
+            // @if feat['htmlmin-min'] || feat['htmlmin-max']
+            .pipe(
+                htmlmin({
+                    collapseInlineTagWhitespace: true,
+                    collapseBooleanAttributes: true,
+                    removeAttributeQuotes: true,
+                    removeScriptTypeAttributes: true,
+                    removeStyleLinkTypeAttributes: true,
+                    removeComments: true,
+                    collapseWhitespace: true,
+                    minifyCSS: true,
+                    minifyJS: true,
+                    ignoreCustomFragments: [/\${.*?}/g], // ignore interpolation expressions
+                })
+            )
+            // @endif
+            .pipe(gulp.dest(dest));
+
+        return stream;
   };
 }
 // @endif

--- a/skeleton/cli-bundler/package.json
+++ b/skeleton/cli-bundler/package.json
@@ -67,5 +67,9 @@
     "gulp-rename": "",
     "gulp-notify": "",
     "gulp-watch": "",
+    
+    // @if feat.plugin
+    "gulp-replace": "",
+    // @endif
   }
 }

--- a/skeleton/plugin/aurelia_project/tasks/build-plugin.ext
+++ b/skeleton/plugin/aurelia_project/tasks/build-plugin.ext
@@ -10,6 +10,7 @@ import {pluginMarkup} from './process-markup';
 import {pluginCSS} from './process-css';
 import {pluginJson} from './process-json';
 import {buildPluginJavaScript} from './transpile';
+import { CLIOptions } from 'aurelia-cli';
 
 function clean() {
   return del('dist');
@@ -19,13 +20,13 @@ export default gulp.series(
   clean,
   gulp.parallel(
     // package.json "module" field pointing to dist/native-modules/index.js
-    pluginMarkup('dist/native-modules'),
+    pluginMarkup('dist/native-modules', CLIOptions.hasFlag('process-markup-aliases'), CLIOptions.hasFlag('verbose')),
     pluginCSS('dist/native-modules'),
     pluginJson('dist/native-modules'),
     buildPluginJavaScript('dist/native-modules', 'es2015'),
 
     // package.json "main" field pointing to dist/native-modules/index.js
-    pluginMarkup('dist/commonjs'),
+    pluginMarkup('dist/commonjs', CLIOptions.hasFlag('process-markup-aliases'), CLIOptions.hasFlag('verbose')),
     pluginCSS('dist/commonjs'),
     pluginJson('dist/commonjs'),
     buildPluginJavaScript('dist/commonjs', 'commonjs'),

--- a/skeleton/plugin/aurelia_project/tasks/build-plugin.json
+++ b/skeleton/plugin/aurelia_project/tasks/build-plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "build-plugin",
+  "description": "Build plugin",
+  "flags": [
+    {
+      "name": "process-markup-aliases",
+      "description": "Replace aliases in template require tags to relative paths for distribution",
+      "type": "boolean"
+    },
+    {
+      "name": "verbose",
+      "description": "Increase log output during build",
+      "type": "boolean"
+    }
+  ]
+}

--- a/skeleton/plugin/aurelia_project/tasks__if_babel/process-markup-aliases.js
+++ b/skeleton/plugin/aurelia_project/tasks__if_babel/process-markup-aliases.js
@@ -1,0 +1,55 @@
+import project from '../aurelia.json';
+import replace from 'gulp-replace';
+import path from 'path';
+
+export const processAliasesToAbsolutePaths = (
+  aliases,
+  root = path.join(__dirname, '../../'),
+  srcRoot = path.join(root, 'src'),
+  aliasRoot = aliases.root
+) => {
+  const absoluteAliasRoot = path.join(root, aliasRoot);
+
+  const absoluteAliases = {};
+
+  for (const [alias, aliasPath] of Object.entries(aliases)) {
+    if (alias === 'root') {
+      continue;
+    }
+    absoluteAliases[alias] = path.join(srcRoot, path.relative(srcRoot, path.join(absoluteAliasRoot, aliasPath)));
+  }
+
+  return absoluteAliases;
+};
+
+export const processMarkupAlias = ({
+  aliases,
+  file,
+  match,
+  requirePath,
+  verbose = false
+}) => {
+  const potentialAlias = requirePath.split('/').shift() || '';
+
+  if (potentialAlias in aliases) {
+    const relativePath = path.relative(file.dirname, aliases[potentialAlias]).replace(/\\/g, '/') || '.';
+    const replacement = match.replace(potentialAlias, relativePath);
+
+    if (verbose) {
+      console.log(`Processing alias
+                        File: ${file.basename}
+                        Alias: ${potentialAlias} in "${match}".
+                        Replacing with: "${replacement}"`);
+    }
+    match = replacement;
+  }
+
+  return match;
+};
+
+const absoluteAliases = processAliasesToAbsolutePaths(project.paths);
+export function processMarkupAliases(verbose = false) {
+  return replace(/require from="(.*)"/g, function(match, requirePath) {
+    return processMarkupAlias({ aliases: absoluteAliases, file: this.file, match, requirePath, verbose });
+  });
+}

--- a/skeleton/plugin/aurelia_project/tasks__if_typescript/process-markup-aliases.ts
+++ b/skeleton/plugin/aurelia_project/tasks__if_typescript/process-markup-aliases.ts
@@ -1,0 +1,64 @@
+import { VinylFile } from 'gulp-typescript/release/types';
+import * as project from '../aurelia.json';
+import * as replace from 'gulp-replace';
+import * as path from 'path';
+
+type Aliases = { [id: string]: string };
+
+export const processAliasesToAbsolutePaths: (aliases: Aliases, root?: string, srcRoot?: string, aliasRoot?: string) => Aliases = (
+    aliases: Aliases,
+    root: string = path.join(__dirname, '../../'),
+    srcRoot: string = path.join(root, 'src'),
+    aliasRoot: string = aliases.root
+): Aliases => {
+    const absoluteAliasRoot: string = path.join(root, aliasRoot);
+
+    const absoluteAliases: Aliases = {};
+
+    for (const [alias, aliasPath] of Object.entries(aliases)) {
+        if (alias === 'root') {
+            continue;
+        }
+        absoluteAliases[alias] = path.join(srcRoot, path.relative(srcRoot, path.join(absoluteAliasRoot, aliasPath)));
+    }
+
+    return absoluteAliases;
+};
+
+export const processMarkupAlias = ({
+    aliases,
+    file,
+    match,
+    requirePath,
+    verbose = false,
+}: {
+    aliases: Aliases;
+    file: VinylFile;
+    match: string;
+    requirePath: string;
+    verbose?: boolean;
+}): string => {
+    const potentialAlias: string = requirePath.split('/').shift() || '';
+
+    if (potentialAlias in aliases) {
+        const relativePath: string = path.relative(file.dirname, aliases[potentialAlias]).replace(/\\/g, '/') || '.';
+        const replacement: string = match.replace(potentialAlias, relativePath);
+
+        if (verbose) {
+            console.log(`Processing alias
+                        File: ${file.basename}
+                        Alias: ${potentialAlias} in "${match}".
+                        Replacing with: "${replacement}"`);
+        }
+        match = replacement;
+    }
+
+    return match;
+};
+
+const absoluteAliases: Aliases = processAliasesToAbsolutePaths(project.paths);
+export function processMarkupAliases(verbose = false): NodeJS.ReadWriteStream {
+    return replace(/require from="(.*)"/g, function(match: string, requirePath: string): string {
+        return processMarkupAlias({ aliases: absoluteAliases, file: this.file, match, requirePath, verbose });
+    });
+}


### PR DESCRIPTION
**I'm submitting a feature request**

* **Library Version:**
Latest CLI

**Current behavior:**
When running build-plugin require paths with aliases in html files will end up in dist. When consuming the plugin this will break since the consuming app does not know how to process the aliases.

* **What is the expected behavior?**
Aliases in html files should be replaced with relative paths to make the plugin usable.

* **What is the motivation / use case for changing the behavior?**
Using aliases in the CLI is supported for the dev-app and this leads to the assumption that it would also work in the plugin code itself. Using aliases makes it easier to use/read and maintain the code in my opinion.

* **Implemented change**
Added conditional flag for au build-plugin to replace aliases in template require tags with relative paths.
This feature will not be used by default so it will not affect any existing plugins.

* **How it works**
1.) Looks at the paths configured in aurelia.json to create aliases relative to `src` since the current setup uses the paths relative to the `dev-app`.
2.) Uses a regex to find `require from="..."` tags in html
3.) If the require path starts with an alias it will replace it with a relative path

* **Example**
_src/my-component/comp.js_
`<require from="elements/file-in-root.html">` --> `<require from="../file-in-root.html">`

* **Limitations**
This only add support for parsing the template. For typescript a different implementation is needed. A new feature request could be created for this.