### PR TITLE
Run aurelia app with webpack inside a docker container

### DIFF
--- a/skeleton/webpack/aurelia_project/tasks/run.ext
+++ b/skeleton/webpack/aurelia_project/tasks/run.ext
@@ -18,7 +18,7 @@ import {CLIOptions, reportWebpackReadiness} from 'aurelia-cli';
 function runWebpack(done) {
   // https://webpack.github.io/docs/webpack-dev-server.html
   let opts = {
-    host: 'localhost',
+    host: '0.0.0.0',
     publicPath: config.output.publicPath,
     filename: config.output.filename,
     hot: project.platform.hmr || CLIOptions.hasFlag('hmr'),


### PR DESCRIPTION
Changed the webpack config so that an aurelia app running with webpack will be exposed from within a container to the host.

Changed "localhost" to "0.0.0.0" : based on what's described [here](https://github.com/webpack/webpack-dev-server/issues/547#issuecomment-284737321)

Also updated the `packge.json` file for the deprecated `opn` [package](https://www.npmjs.com/package/opn) to its new version `open` [package](https://www.npmjs.com/package/open)