### PR TITLE
feat(plugin, build-plugin): debug/develop plugin from consuming app with npm link

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -320,7 +320,6 @@ exports.Bundle = class {
               sourceRoot = sourceRoot.split('/', 1)[0];
             }
             sourceMap.sourceRoot = sourceRoot;
-          
             needsSourceMap = true;
             content = Convert.removeMapFileComments(currentFile.contents);
           }

--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -320,6 +320,7 @@ exports.Bundle = class {
               sourceRoot = sourceRoot.split('/', 1)[0];
             }
             sourceMap.sourceRoot = sourceRoot;
+          
             needsSourceMap = true;
             content = Convert.removeMapFileComments(currentFile.contents);
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3286,8 +3286,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3305,13 +3304,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3324,18 +3321,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3438,8 +3432,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3449,7 +3442,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3462,20 +3454,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3492,7 +3481,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3565,8 +3553,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3576,7 +3563,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3652,8 +3638,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3683,7 +3668,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3701,7 +3685,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3740,13 +3723,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3286,7 +3286,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3304,11 +3305,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3321,15 +3324,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3432,7 +3438,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3442,6 +3449,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3454,17 +3462,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3481,6 +3492,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3553,7 +3565,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3563,6 +3576,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3638,7 +3652,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3668,6 +3683,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3685,6 +3701,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3723,11 +3740,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/skeleton/cli-bundler/aurelia_project/tasks/watch.ext
+++ b/skeleton/cli-bundler/aurelia_project/tasks/watch.ext
@@ -12,17 +12,62 @@ import * as gulpWatch from 'gulp-watch';
 import * as debounce from 'debounce';
 import * as project from '../aurelia.json';
 // @endif
+// @if feat.plugin
+import { buildPluginJavaScript } from './transpile';
+import { pluginMarkup } from './process-markup';
+import { pluginCSS } from './process-css';
+import { pluginJson } from './process-json';
+// @endif
+// @if !feat.plugin
 import transpile from './transpile';
 import processMarkup from './process-markup';
 import processCSS from './process-css';
 import processJson from './process-json';
 import copyFiles from './copy-files';
+// @endif
 import { build } from 'aurelia-cli';
 
 const debounceWaitTime = 100;
 let isBuilding = false;
 let pendingRefreshPaths = [];
 let watchCallback = () => { };
+// @if feat.plugin
+function processMarkupPlugin() {
+  return gulp.parallel(
+    pluginMarkup('dist/native-modules'),
+    pluginMarkup('dist/commonjs')
+  )
+}
+
+function processCSSPlugin() {
+  return gulp.parallel(
+    pluginCSS('dist/native-modules'),
+    pluginCSS('dist/commonjs')
+  )
+}
+
+function processJsonPlugin() {
+  return gulp.parallel(
+    pluginJson('dist/native-modules'),
+    pluginJson('dist/commonjs')
+  )
+}
+
+function transpilePlugin() {
+  return gulp.parallel(
+    buildPluginJavaScript('dist/native-modules', 'es2015'),
+    buildPluginJavaScript('dist/commonjs', 'commonjs')
+  );
+}
+
+let watches = [
+  { name: 'transpile', callback: transpilePlugin(), source: project.transpiler.source },
+  { name: 'markup', callback: processMarkupPlugin(), source: project.markupProcessor.source },
+  { name: 'CSS', callback: processCSSPlugin(), source: project.cssProcessor.source },
+  { name: 'JSON', callback: processJsonPlugin(), source: project.jsonProcessor.source }
+];
+// @endif
+// @if !feat.plugin
 let watches = [
   { name: 'transpile', callback: transpile, source: project.transpiler.source },
   { name: 'markup', callback: processMarkup, source: project.markupProcessor.source },
@@ -35,6 +80,7 @@ if (typeof project.build.copyFiles === 'object') {
     watches.push({ name: 'file copy', callback: copyFiles, source: src });
   }
 }
+// @endif
 
 let watch = (callback) => {
   watchCallback = callback || watchCallback;
@@ -106,6 +152,24 @@ let refresh = debounce(() => {
 
   log(`Watcher: Running ${refreshTasks.map(x => x.name).join(', ')} tasks on next build...`);
 
+// @if feat.plugin
+  let toExecute = gulp.series(
+    gulp.parallel(refreshTasks.map(x => x.callback)),
+    (done) => {
+      isBuilding = false;
+      watchCallback();
+      done();
+      if (pendingRefreshPaths.length > 0) {
+        log('Watcher: Found more pending changes after finishing build, triggering next one...');
+        refresh();
+      }
+    }
+  );
+  
+  toExecute();
+}, debounceWaitTime);
+// @endif
+// @if !feat.plugin
   let toExecute = gulp.series(
     readProjectConfiguration,
     gulp.parallel(refreshTasks.map(x => x.callback)),
@@ -124,16 +188,17 @@ let refresh = debounce(() => {
   toExecute();
 }, debounceWaitTime);
 
-function log(message/* @if feat.typescript **: string/* @endif */) {
-  console.log(message);
-}
-
 function readProjectConfiguration() {
   return build.src(project);
 }
 
 function writeBundles() {
   return build.dest();
+}
+// @endif
+
+function log(message/* @if feat.typescript **: string/* @endif */) {
+  console.log(message);
 }
 
 export default watch;

--- a/skeleton/cli-bundler/aurelia_project/tasks__if_typescript/transpile.ts
+++ b/skeleton/cli-bundler/aurelia_project/tasks__if_typescript/transpile.ts
@@ -5,13 +5,15 @@ import * as rename from 'gulp-rename';
 import * as ts from 'gulp-typescript';
 import * as project from '../aurelia.json';
 import * as fs from 'fs';
+import { CLIOptions, build, Configuration } from 'aurelia-cli';
 import * as through from 'through2';
-import {CLIOptions, build} from 'aurelia-cli';
+import * as gulpSourcemaps from 'gulp-sourcemaps';
+import * as gulpIf from 'gulp-if';
 
 function configureEnvironment() {
   let env = CLIOptions.getEnvironment();
 
-  return gulp.src(`aurelia_project/environments/${env}.ts`, {since: gulp.lastRun(configureEnvironment)})
+  return gulp.src(`aurelia_project/environments/${env}.ts`, { since: gulp.lastRun(configureEnvironment) })
     .pipe(rename('environment.ts'))
     .pipe(through.obj(function (file, _, cb) {
       // https://github.com/aurelia/cli/issues/1031
@@ -50,9 +52,21 @@ export function buildPluginJavaScript(dest, format) {
       typescript: require('typescript'),
       module: format
     });
+
+    let defaultBuildOptions = {
+      minify: 'stage & prod',
+      sourcemaps: 'dev & stage',
+      rev: false
+    };
+
+    let buildOptions = new Configuration(project.build.options, defaultBuildOptions);
+    let sourcemaps : boolean = buildOptions.isApplicable('sourcemaps');
+
     return gulp.src(project.transpiler.dtsSource)
       .pipe(gulp.src(project.plugin.source.js))
+      .pipe(gulpIf(sourcemaps, gulpSourcemaps.init()))
       .pipe(typescriptCompiler())
+      .pipe(gulpIf(sourcemaps, gulpSourcemaps.write('.', { includeContent: false, sourceRoot: '../../src' })))
       .pipe(gulp.dest(dest));
   };
 }

--- a/skeleton/common/tsconfig.json__if_typescript
+++ b/skeleton/common/tsconfig.json__if_typescript
@@ -32,7 +32,7 @@
     "types": ["node", "jest"],
     // @endif
 
-    // @if feat.webpack && feat['postcss-typical'] && feat.protractor
+    // @if (feat.webpack && feat['postcss-typical'] && feat.protractor) || feat.plugin
     "typeRoots": ["./node_modules/@types"],
     // @endif
 

--- a/skeleton/plugin/aurelia_project/aurelia.json
+++ b/skeleton/plugin/aurelia_project/aurelia.json
@@ -2,11 +2,7 @@
   "type": "project:plugin",
   "paths": {
     "root": "dev-app",
-    "resources": "../src",
-    "elements": "../src/elements",
-    "attributes": "../src/attributes",
-    "valueConverters": "../src/value-converters",
-    "bindingBehaviors": "../src/binding-behaviors"
+    "resources": "../src"
   },
   "plugin": {
     "source": {

--- a/skeleton/plugin/aurelia_project/aurelia.json
+++ b/skeleton/plugin/aurelia_project/aurelia.json
@@ -2,7 +2,11 @@
   "type": "project:plugin",
   "paths": {
     "root": "dev-app",
-    "resources": "../src"
+    "resources": "../src",
+    "elements": "../src/elements",
+    "attributes": "../src/attributes",
+    "valueConverters": "../src/value-converters",
+    "bindingBehaviors": "../src/binding-behaviors"    
   },
   "plugin": {
     "source": {

--- a/skeleton/plugin/aurelia_project/tasks/build-plugin.ext
+++ b/skeleton/plugin/aurelia_project/tasks/build-plugin.ext
@@ -9,13 +9,20 @@ import * as del from 'del';
 import {pluginMarkup} from './process-markup';
 import {pluginCSS} from './process-css';
 import {pluginJson} from './process-json';
-import {buildPluginJavaScript} from './transpile';
+import { buildPluginJavaScript } from './transpile';
+import { CLIOptions } from 'aurelia-cli';
+import watch from './watch';
+
+let doneMessage = 'Finish building Aurelia plugin to dist/commonjs and dist/native-modules.';
 
 function clean() {
-  return del('dist');
+  if (CLIOptions.getEnvironment()==='prod') {
+    return del(['dist']);
+  }
+  return new Promise((resolve) => setTimeout(resolve, 100));
 }
 
-export default gulp.series(
+let build = gulp.series(
   clean,
   gulp.parallel(
     // package.json "module" field pointing to dist/native-modules/index.js
@@ -28,7 +35,22 @@ export default gulp.series(
     pluginMarkup('dist/commonjs'),
     pluginCSS('dist/commonjs'),
     pluginJson('dist/commonjs'),
-    buildPluginJavaScript('dist/commonjs', 'commonjs'),
-  ),
-  () => console.log('Finish building Aurelia plugin to dist/commonjs and dist/native-modules')
+    buildPluginJavaScript('dist/commonjs', 'commonjs')
+  )
 );
+
+let main;
+
+if (CLIOptions.hasFlag('watch')) {
+  main = gulp.series(
+    build,
+    (done) => { console.log(doneMessage + 'Watching for changes'); watch(null, true); done(); }
+  );
+} else {
+  main = gulp.series(
+    build,
+    () => console.log(doneMessage)
+  );
+}
+
+export { main as default };

--- a/skeleton/plugin/package.json
+++ b/skeleton/plugin/package.json
@@ -17,6 +17,8 @@
     "dist"
   ],
   "devDependencies": {
+    "gulp-sourcemaps": "^2.6.5",
+    "gulp-if": "^2.0.2",
     "del": ""
   }
 }

--- a/skeleton/vscode/.vscode/launch.json__if_cli-bundler
+++ b/skeleton/vscode/.vscode/launch.json__if_cli-bundler
@@ -9,10 +9,10 @@
       "type": "chrome",
       "request": "launch",
       "url": "http://localhost:9000",
-      "webRoot": "${workspaceRoot}/src",
+      "webRoot": "${workspaceRoot}",
       "userDataDir": "${workspaceRoot}/.chrome",
       "sourceMapPathOverrides": {
-        "../src/*": "${webRoot}/*"
+        "src/*": "${webRoot}/src/*"
       }
     },
     {

--- a/skeleton/vscode/.vscode/launch.json__if_webpack
+++ b/skeleton/vscode/.vscode/launch.json__if_webpack
@@ -12,7 +12,8 @@
       "webRoot": "${workspaceRoot}/src",
       "userDataDir": "${workspaceRoot}/.chrome",
       "sourceMapPathOverrides": {
-        "webpack:///./src/*": "${webRoot}/*"
+        "webpack:///./src/*": "${webRoot}/*",
+        "webpack:///./node_modules/*": "${workspaceRoot}/node_modules/*",
       }
     }
   ]

--- a/skeleton/webpack/package.json
+++ b/skeleton/webpack/package.json
@@ -69,5 +69,6 @@
     "istanbul-instrumenter-loader": "",
     "open": "",
     "webpack-bundle-analyzer": "",
+    "source-map-loader": "",
   }
 }

--- a/skeleton/webpack/webpack.config.js
+++ b/skeleton/webpack/webpack.config.js
@@ -59,6 +59,7 @@ module.exports = ({ production, server, extractCss, coverage, analyze, karma } =
     // @if feat.babel
     extensions: ['.js'],
     // @endif
+    symlinks: false,
     modules: [srcDir, 'node_modules'],
     // Enforce single aurelia-binding, to avoid v1/v2 duplication due to
     // out-of-date dependencies on 3rd party aurelia plugins
@@ -291,6 +292,11 @@ module.exports = ({ production, server, extractCss, coverage, analyze, karma } =
       { test: /\.woff(\?v=[0-9]\.[0-9]\.[0-9])?$/i, loader: 'url-loader', options: { limit: 10000, mimetype: 'application/font-woff' } },
       // load these fonts normally, as files:
       { test: /\.(ttf|eot|svg|otf)(\?v=[0-9]\.[0-9]\.[0-9])?$/i, loader: 'file-loader' },
+      ...when(!production, {
+        test: /\.js$/,
+        use: ["source-map-loader"],
+        enforce: "pre"
+      }),
       // @if feat.typescript
       ...when(coverage, {
         test: /\.[jt]s$/i, loader: 'istanbul-instrumenter-loader',


### PR DESCRIPTION
**I'm submitting a feature request**

* **Library Version:**
1.0.1

**Please tell us about your environment:**
* **Operating System:**
Windows [10]

* **Node Version:**
10.15.3

* **NPM Version:**
6.2.0

* **Browser:**
Chrome 75

* **Language:**
TypeScript 3.3

* **Loader/bundler:**
Webpack

**Current behavior:**
You create aurelia plugin/module for reuse in multiple enterprise apps. When you consume the plugin from the app, you cannot add breakpoints to the plugin neither you can modify the source code while debuging the app. 

* **What is the expected behavior?**
I would like to develop the app/plugins from an integrated environment, set breakpoints and debug all the code from a VSCode workspace

* **What is the motivation / use case for changing the behavior?**
In my current projects i use jspm link and in order to debug/build my app and plugin, i have two editors open and cannot live change the code in the plugins.
I want to use the CLI for new projects and npm link my plugins to my developing project, add the plugins from node_modules to my VSCode workspace, and set break points to .ts source files. Also by using au build-plugin --watch i am able to live reload the app when i modify the source code in the plugin. 
The hmr works for the app's files not for plugin where it reloads