### PR TITLE
Revert hostname change in webpack

### DIFF
--- a/build/tasks/release-checks/tasks/check-javascript-errors.js
+++ b/build/tasks/release-checks/tasks/check-javascript-errors.js
@@ -7,8 +7,7 @@ module.exports = class CheckJavascriptErrors extends Task {
   constructor(url) {
     super('Check javascript errors');
 
-    // somehow puppeteer/win32 thinks http://0.0.0.0:5000 is an invalid address.
-    this.url = url.replace('//0.0.0.0', '//localhost');
+    this.url = url;
   }
 
   execute() {

--- a/build/tasks/release-checks/tasks/take-screenshot-of-page.js
+++ b/build/tasks/release-checks/tasks/take-screenshot-of-page.js
@@ -7,8 +7,7 @@ module.exports = class TakeScreenShotOfPage extends Task {
   constructor(url, path) {
     super('Take screenshot of page');
 
-    // somehow puppeteer/win32 thinks http://0.0.0.0:5000 is an invalid address.
-    this.url = url.replace('//0.0.0.0', '//localhost');
+    this.url = url;
     this.path = path;
   }
 

--- a/skeleton/webpack/aurelia_project/tasks/run.ext
+++ b/skeleton/webpack/aurelia_project/tasks/run.ext
@@ -18,7 +18,7 @@ import {CLIOptions, reportWebpackReadiness} from 'aurelia-cli';
 function runWebpack(done) {
   // https://webpack.github.io/docs/webpack-dev-server.html
   let opts = {
-    host: '0.0.0.0',
+    host: 'localhost',
     publicPath: config.output.publicPath,
     filename: config.output.filename,
     hot: project.platform.hmr || CLIOptions.hasFlag('hmr'),


### PR DESCRIPTION
Browser in windows has issue to deal with `http://0.0.0.0:8080` ("This site can't be reached"), have to use `http://localhost:8080` in Windows browsers.

@shahabganji this reverts #1122. This is needed because `au run --open` opens browser with the hostname in run task config.

Anyone knows some other way around this Windows edge case?