### PR TITLE
refactor(Build) Don't copy skeleton

### DIFF
--- a/bin/aurelia-cli.js
+++ b/bin/aurelia-cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-'use strict';
+
 const resolve = require('resolve');
 
 const semver = require('semver');
@@ -25,7 +25,7 @@ resolve('aurelia-cli', {
   let cli;
 
   if (commandName === 'new' || error) {
-    cli = new (require('../lib/index').CLI);
+    cli = new (require('../dist/index').CLI);
     cli.options.runningGlobally = true;
   } else {
     cli = new (require(projectLocalCli).CLI);

--- a/build/tasks/release-check.js
+++ b/build/tasks/release-check.js
@@ -2,12 +2,12 @@ const gulp = require('gulp');
 const path = require('path');
 const SuiteRunner = require('./release-checks/suite-runner');
 const LogManager = require('aurelia-logging');
-const Utils = require('../../dist/lib/build/utils');
+const Utils = require('../../dist/build/utils');
 const {MessageHistoryLogger} = require('./release-checks/message-history-logger');
 const TestProjectsSelector = require('./release-checks/test-projects-selector');
 const Reporter = require('./release-checks/reporter');
 const del = require('del');
-const ConsoleUI = require('../../dist/lib/ui').ConsoleUI;
+const ConsoleUI = require('../../dist/ui').ConsoleUI;
 const ui = new ConsoleUI();
 const c = require('ansi-colors');
 

--- a/build/tasks/release-checks/message-history-logger.js
+++ b/build/tasks/release-checks/message-history-logger.js
@@ -1,4 +1,4 @@
-const fs = require('../../../dist/lib/file-system');
+const fs = require('../../../dist/file-system');
 
 exports.MessageHistoryLogger = class {
   constructor(ui) {

--- a/build/tasks/release-checks/suite-runner.js
+++ b/build/tasks/release-checks/suite-runner.js
@@ -1,7 +1,7 @@
-const Utils = require('../../../dist/lib/build/utils');
+const Utils = require('../../../dist/build/utils');
 const suiteSteps = require('./suite-steps');
 const StepRunner = require('./step-runner');
-const fs = require('../../../dist/lib/file-system');
+const fs = require('../../../dist/file-system');
 
 module.exports = class SuiteRunner {
   constructor(context, reporter) {

--- a/build/tasks/release-checks/suite-steps.js
+++ b/build/tasks/release-checks/suite-steps.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const tasks = require('./tasks/index');
 const tests = require('./tests/index');
-const applicable = require('../../../dist/lib/workflow/applicable');
+const applicable = require('../../../dist/workflow/applicable');
 
 module.exports = function(suite) {
   const features = suite.split('_');

--- a/build/tasks/release-checks/tasks/install-latest-aurelia-cli.js
+++ b/build/tasks/release-checks/tasks/install-latest-aurelia-cli.js
@@ -1,5 +1,5 @@
 const Task = require('./task');
-const Yarn = require('../../../../dist/package-managers/yarn').Yarn;
+const NPM = require('../../../../dist/package-managers/npm').NPM;
 const LogManager = require('aurelia-logging');
 const logger = LogManager.getLogger('link-aurelia-cli');
 const CLIOptions = require('../../../../dist/cli-options').CLIOptions;
@@ -36,7 +36,7 @@ module.exports = class InstallLatestAureliaCLI extends Task {
     const forkUrl = await this.determineURL();
     logger.debug('Install latest Aurelia-CLI (' + forkUrl + ') ' + context.workingDirectory);
 
-    const yarn = new Yarn();
-    return yarn.install([forkUrl], context.workingDirectory);
+    const npm = new NPM();
+    return npm.install([forkUrl], context.workingDirectory);
   }
 };

--- a/build/tasks/release-checks/tasks/install-latest-aurelia-cli.js
+++ b/build/tasks/release-checks/tasks/install-latest-aurelia-cli.js
@@ -1,10 +1,10 @@
 const Task = require('./task');
-const Yarn = require('../../../../dist/lib/package-managers/yarn').Yarn;
+const Yarn = require('../../../../dist/package-managers/yarn').Yarn;
 const LogManager = require('aurelia-logging');
 const logger = LogManager.getLogger('link-aurelia-cli');
-const CLIOptions = require('../../../../dist/lib/cli-options').CLIOptions;
+const CLIOptions = require('../../../../dist/cli-options').CLIOptions;
 const cliOptions = new CLIOptions();
-const ConsoleUI = require('../../../../dist/lib/ui').ConsoleUI;
+const ConsoleUI = require('../../../../dist/ui').ConsoleUI;
 const ui = new ConsoleUI();
 
 let userArgs = process.argv.slice(2);

--- a/build/tasks/release-checks/tasks/install-node-modules.js
+++ b/build/tasks/release-checks/tasks/install-node-modules.js
@@ -1,5 +1,5 @@
 const Task = require('./task');
-const Yarn = require('../../../../dist/lib/package-managers/yarn').Yarn;
+const Yarn = require('../../../../dist/package-managers/yarn').Yarn;
 const LogManager = require('aurelia-logging');
 const logger = LogManager.getLogger('install-node-modules');
 const fs = require('fs');

--- a/build/tasks/release-checks/tasks/install-node-modules.js
+++ b/build/tasks/release-checks/tasks/install-node-modules.js
@@ -1,5 +1,5 @@
 const Task = require('./task');
-const Yarn = require('../../../../dist/package-managers/yarn').Yarn;
+const NPM = require('../../../../dist/package-managers/npm').NPM;
 const LogManager = require('aurelia-logging');
 const logger = LogManager.getLogger('install-node-modules');
 const fs = require('fs');
@@ -18,7 +18,7 @@ module.exports = class InstallNodeModules extends Task {
 
     logger.debug('installing packages in ' + context.workingDirectory);
 
-    const yarn = new Yarn();
-    return yarn.install([], context.workingDirectory);
+    const npm = new NPM();
+    return npm.install([], context.workingDirectory);
   }
 };

--- a/build/tasks/release-checks/test-projects-selector.js
+++ b/build/tasks/release-checks/test-projects-selector.js
@@ -1,6 +1,6 @@
-const CLIOptions = require('../../../dist/lib/cli-options').CLIOptions;
+const CLIOptions = require('../../../dist/cli-options').CLIOptions;
 const cliOptions = new CLIOptions();
-const fs = require('../../../dist/lib/file-system');
+const fs = require('../../../dist/file-system');
 const path = require('path');
 const _ = require('lodash');
 
@@ -9,7 +9,7 @@ Object.assign(cliOptions, {
   args: userArgs.slice(1)
 });
 
-const ConsoleUI = require('../../../dist/lib/ui').ConsoleUI;
+const ConsoleUI = require('../../../dist/ui').ConsoleUI;
 const ui = new ConsoleUI();
 
 module.exports = class TestProjectsSelector {

--- a/build/tasks/release-checks/tests/generic/au-generate.js
+++ b/build/tasks/release-checks/tests/generic/au-generate.js
@@ -1,6 +1,6 @@
 const Test = require('../test');
 const ExecuteCommand = require('../../tasks/execute-command');
-const fs = require('../../../../../dist/lib/file-system');
+const fs = require('../../../../../dist/file-system');
 const path = require('path');
 const _ = require('lodash');
 

--- a/build/tasks/update-dependenciesjs.js
+++ b/build/tasks/update-dependenciesjs.js
@@ -3,7 +3,7 @@ const latestVersion = require('latest-version');
 const fs = require('fs');
 const path = require('path');
 
-const depJsonPath = path.resolve(__dirname, '../../dist/lib/dependencies.json');
+const depJsonPath = path.resolve(__dirname, '../../dist/dependencies.json');
 
 const ignore = ['text', 'gulp', 'extract-text-webpack-plugin'];
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -21,8 +21,7 @@ exports.CLI = class {
   // this.logger.error prints nothing in run(),
   // directly use this.ui.log.
   run(cmd, args) {
-    const isRunningFromDist = __filename.includes('dist');
-    const version = `${this.options.runningGlobally ? 'Global' : 'Local'} aurelia-cli v${require(`${isRunningFromDist ? '../../' : '../'}package.json`).version}`;
+    const version = `${this.options.runningGlobally ? 'Global' : 'Local'} aurelia-cli v${require('../package.json').version}`;
 
     if (cmd === '--version' || cmd === '-v') {
       return this.ui.log(version);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3470,7 +3470,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3488,11 +3489,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3505,15 +3508,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3616,7 +3622,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3626,6 +3633,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3638,17 +3646,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3665,6 +3676,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3737,7 +3749,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3747,6 +3760,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3822,7 +3836,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3852,6 +3867,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3869,6 +3885,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3907,11 +3924,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/aurelia/cli/issues"
   },
   "bin": {
-    "aurelia": "dist/bin/aurelia-cli.js",
-    "au": "dist/bin/aurelia-cli.js"
+    "aurelia": "bin/aurelia-cli.js",
+    "au": "bin/aurelia-cli.js"
   },
   "engines": {
     "node": ">=8.9.0"
@@ -24,17 +24,18 @@
     "build:ts": "tsc",
     "build:ts:watch": "npm run build:ts -- --watch",
     "build:dts": "tsc -d --emitDeclarationOnly --allowJs false",
-    "build:copy-files": "copyfiles -e ./skeleton/**/*.{js,ts} -e ./lib/**/*.{js,ts} ./lib/**/* ./skeleton/**/* ./dist",
+    "build:copy-files": "copyfiles -u 1 -e ./lib/**/*.{js,ts} ./lib/**/* ./dist",
     "lint": "gulp lint",
-    "pretest": "npm run lint",
+    "pretest": "npm run build && npm run lint",
     "test": "jasmine-ts",
     "coverage": "nyc jasmine-ts",
-    "test:watch": "nodemon -x 'npm test'"
+    "test:watch": "nodemon -x 'npm test'",
+    "prepare": "npm run build"
   },
   "license": "MIT",
   "author": "Rob Eisenberg <rob@bluespire.com> (http://robeisenberg.com/)",
-  "main": "dist/lib/index.js",
-  "types": "dist/lib/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/aurelia/cli"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:ts": "tsc",
     "build:ts:watch": "npm run build:ts -- --watch",
     "build:dts": "tsc -d --emitDeclarationOnly --allowJs false",
-    "build:copy-files": "copyfiles -u 1 -e ./lib/**/*.{js,ts} ./lib/**/* ./dist",
+    "build:copy-files": "copyfiles -u 1 -e \"./lib/**/*.{js,ts}\" \"./lib/**/*\" ./dist",
     "lint": "gulp lint",
     "pretest": "npm run build && npm run lint",
     "test": "jasmine-ts",

--- a/skeleton/cli-bundler/aurelia_project/tasks__if_babel/transpile.js
+++ b/skeleton/cli-bundler/aurelia_project/tasks__if_babel/transpile.js
@@ -8,7 +8,9 @@ import project from '../aurelia.json';
 import fs from 'fs';
 import through from 'through2';
 import { CLIOptions, build, Configuration } from 'aurelia-cli';
-import gulpSourcemaps from 'gulp-sourcemaps';
+// @if feat.plugin
+import * as gulpSourcemaps from 'gulp-sourcemaps';
+// @endif
 
 let env = CLIOptions.getEnvironment();
 const buildOptions = new Configuration(project.build.options);

--- a/skeleton/cli-bundler/aurelia_project/tasks__if_typescript/transpile.ts
+++ b/skeleton/cli-bundler/aurelia_project/tasks__if_typescript/transpile.ts
@@ -7,7 +7,9 @@ import * as project from '../aurelia.json';
 import * as fs from 'fs';
 import * as through from 'through2';
 import { CLIOptions, build, Configuration } from 'aurelia-cli';
+// @if feat.plugin
 import * as gulpSourcemaps from 'gulp-sourcemaps';
+// @endif
 
 function configureEnvironment() {
   let env = CLIOptions.getEnvironment();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,10 @@
       "target": "es6"
   },
   "include": [
-      "./bin/*",
-      "./lib/**/*"
+    "./lib/**/*"
   ],
   "exclude": [
+    "./bin/*",
     "./skeleton/**/*"
   ]
 }


### PR DESCRIPTION
Refactor & update based on PR comments by @3cp 
- Improved build time by keeping skeleton files as-is, they will not be copied to the dist folder.
- Added build step to pretest.
- Lib is now directly transpiled to dist instead of dist/lib
- Bin is no longer transpiled as it only serves as entrypoint

Related to #1067 