### PR TITLE
fix(webpack): avoid unnecessary breaking change on argument

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-cli",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/skeleton/webpack/package.json
+++ b/skeleton/webpack/package.json
@@ -71,15 +71,15 @@
     "tree-kill": "^1.2.1",
   },
   "scripts": {
-    "build": "webpack --env.production --env.extractCss",
-    "build:dev": "webpack --env.extractCss",
-    "analyze": "webpack --env.production --env.analyze",
+    "build": "webpack --env.production --extractCss",
+    "build:dev": "webpack --extractCss",
+    "analyze": "webpack --env.production --analyze",
     // @if feat['dotnet-core']
-    "start": "webpack-dev-server --env.extractCss"
+    "start": "webpack-dev-server --extractCss"
     // @endif
 
     // @if feat.web
-    "start": "webpack-dev-server --env.extractCss"
+    "start": "webpack-dev-server --extractCss"
     // @endif
   }
 }

--- a/skeleton/webpack/webpack.config.js
+++ b/skeleton/webpack/webpack.config.js
@@ -51,7 +51,7 @@ const sassRules = [
 ];
 // @endif
 
-module.exports = ({ production, extractCss, analyze, tests, hmr, port, host } = {}) => ({
+module.exports = ({ production } = {}, {extractCss, analyze, tests, hmr, port, host } = {}) => ({
   resolve: {
     // @if feat.typescript
     extensions: ['.ts', '.js'],
@@ -208,7 +208,7 @@ module.exports = ({ production, extractCss, analyze, tests, hmr, port, host } = 
     contentBase: outDir,
     // serve index.html for all 404 (required for push-state)
     historyApiFallback: true,
-    hot: hmr,
+    hot: hmr || project.platform.hmr,
     port: port || project.platform.port,
     host: host || project.platform.host
   },


### PR DESCRIPTION
With this fix, `au run --analyze` `au run --hmr` will continue to work.