### PR TITLE
Change e2e Tests default behavior to headless

### DIFF
--- a/skeleton/cypress/README.md
+++ b/skeleton/cypress/README.md
@@ -4,11 +4,11 @@ You need the app running for integration test.
 
 First, run `au run` and keep it running.
 
-Then run `au cypress --interactive` to run cypress in interactive mode.
+Then run `au cypress` to run cypress in interactive mode.
 
-To perform a test-run and reports the results, do `au cypress`.
+To perform a test-run and reports the results, do `au cypress --run`.
 
-To ask the `cypress` to start the application first and then start testing: `au cypress --start`
+To ask the `cypress` to start the application first and then start testing: `au cypress --run --start`
 
 The two following flags are useful when using `--start` flag:
  * To change dev server port, do `au cypress --start --port 8888`.

--- a/skeleton/cypress/README.md
+++ b/skeleton/cypress/README.md
@@ -4,9 +4,9 @@ You need the app running for integration test.
 
 First, run `au run` and keep it running.
 
-Then run `au cypress` to run cypress in interactive mode.
+Then run `au cypress --interactive` to run cypress in interactive mode.
 
-To perform a test-run and reports the results, do `au cypress --run`.
+To perform a test-run and reports the results, do `au cypress`.
 
 To ask the `cypress` to start the application first and then start testing: `au cypress --start`
 

--- a/skeleton/cypress/aurelia_project/tasks/cypress.ext
+++ b/skeleton/cypress/aurelia_project/tasks/cypress.ext
@@ -15,7 +15,7 @@ import { default as runAppServer, shutdownAppServer } from './run';
 // @endif
 
 const runCypress = (cb) => {
-  if (CLIOptions.hasFlag('run')) {
+  if (!CLIOptions.hasFlag('interactive')) {
     cypress
       .run(config)
       .then(results => (results.totalFailed === 0 ? cb() : cb('Run failed!')))

--- a/skeleton/cypress/aurelia_project/tasks/cypress.ext
+++ b/skeleton/cypress/aurelia_project/tasks/cypress.ext
@@ -15,7 +15,7 @@ import { default as runAppServer, shutdownAppServer } from './run';
 // @endif
 
 const runCypress = (cb) => {
-  if (!CLIOptions.hasFlag('interactive')) {
+  if (CLIOptions.hasFlag('run')) {
     cypress
       .run(config)
       .then(results => (results.totalFailed === 0 ? cb() : cb('Run failed!')))

--- a/skeleton/cypress/package.json
+++ b/skeleton/cypress/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "e2e": "au cypress --interactive",
-    "e2e:headless": "au cypress --start"
+    "e2e": "au cypress",
+    "e2e:headless": "au cypress --start --run"
   },
   "devDependencies": {
     // @if feat.typescript

--- a/skeleton/cypress/package.json
+++ b/skeleton/cypress/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "e2e": "au cypress",
-    "e2e:headless": "au cypress --run --start"
+    "e2e": "au cypress --interactive",
+    "e2e:headless": "au cypress --start"
   },
   "devDependencies": {
     // @if feat.typescript

--- a/skeleton/docker/Dockerfile
+++ b/skeleton/docker/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM node:12 as build
+FROM node:lts as build-stage
 
 // @if feat.cypress || feat.protractor || feat.karma
 ENV DEBIAN_FRONTEND=noninteractive
@@ -32,12 +32,12 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-
   && ( dpkg -i /tmp/google-chrome-stable_current_amd64.deb ||  apt-get -fy install)  \
   && rm -rf /tmp/google-chrome-stable_current_amd64.deb \
   &&  sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
-           "/opt/google/chrome/google-chrome" \
+          "/opt/google/chrome/google-chrome" \
   && google-chrome --version
 
 // @endif
 
-RUN npm install -g aurelia-cli@1.1.0
+RUN npm install -g aurelia-cli@1.2.0
 
 
 WORKDIR /app
@@ -84,32 +84,32 @@ RUN npm run e2e:headless
 // @endif
 
 # build
-FROM build as publish
+FROM build-stage as publish-stage
 RUN au build --env prod
 
-# run-time stage
-FROM nginx:alpine as run-time
+# production stage
+FROM nginx:alpine as production-stage
 COPY nginx.conf /etc/nginx/nginx.conf
 WORKDIR /usr/share/nginx/html
 
 // @if feat.webpack && !feat["dotnet-core"]
-COPY --from=publish /app/dist/ .
+COPY --from=publish-stage /app/dist/ .
 // @endif
 
 // @if feat.webpack && feat["dotnet-core"]
-COPY --from=publish /app/wwwroot/dist/ .
+COPY --from=publish-stage /app/wwwroot/dist/ .
 // @endif
 
 // @if feat["cli-bundler"] && feat["dotnet-core"]
-COPY --from=publish /app/wwwroot/ .
+COPY --from=publish-stage /app/wwwroot/ .
 // @endif
 
 // @if feat["cli-bundler"] && !feat["dotnet-core"]
   // @if feat["scaffold-navigation"]
-COPY --from=publish /app/bootstrap/dist/ ./bootstrap/dist/
+COPY --from=publish-stage /app/bootstrap/dist/ ./bootstrap/dist/
   // @endif
-COPY --from=publish /app/scripts/ ./scripts/
-COPY --from=publish /app/index.html/ .
+COPY --from=publish-stage /app/scripts/ ./scripts/
+COPY --from=publish-stage /app/index.html/ .
 // @endif
 
 EXPOSE 80

--- a/skeleton/docker/docker-compose.yml
+++ b/skeleton/docker/docker-compose.yml
@@ -3,6 +3,9 @@ version: "3.7"
 services:
   /* @echo projectName */:
     image: /* @echo projectName */:0.1.0
+    build:
+      context: . # relative to docker-compose.yml
+      dockerfile: Dockerfile
     ports:
       - "5050:80"
     restart: unless-stopped

--- a/skeleton/protractor/README.md
+++ b/skeleton/protractor/README.md
@@ -6,7 +6,7 @@ First, run `au run` and keep it running.
 
 Then run `au protractor`.
 
-To perform a test-run and reports the results, do `au protractor --run`.
+To perform a test-run in interactive mode, do `au protractor --interactive`.
 
 To ask the `protractor` to start the application first and then start testing: `au protractor --start`
 
@@ -15,4 +15,4 @@ The two following flags are useful when using `--start` flag:
  * To change dev server host, do `au protractor --start --host 127.0.0.1`
 
 
-**PS:** It is also possible to mix the flags `au protractor --run --start --port 7070 --host 127.0.0.1`
+**PS:** It is also possible to mix the flags `au protractor --interactive --start --port 7070 --host 127.0.0.1`

--- a/skeleton/protractor/README.md
+++ b/skeleton/protractor/README.md
@@ -6,13 +6,13 @@ First, run `au run` and keep it running.
 
 Then run `au protractor`.
 
-To perform a test-run in interactive mode, do `au protractor --interactive`.
+To perform a test-run in interactive mode, do `au protractor`.
 
-To ask the `protractor` to start the application first and then start testing: `au protractor --start`
+To ask the `protractor` to start the application first and then start testing: `au protractor --headless --start`
 
 The two following flags are useful when using `--start` flag:
  * To change dev server port, do `au protractor --start --port 8888`.
  * To change dev server host, do `au protractor --start --host 127.0.0.1`
 
 
-**PS:** It is also possible to mix the flags `au protractor --interactive --start --port 7070 --host 127.0.0.1`
+**PS:** It is also possible to mix the flags `au protractor --headless --start --port 7070 --host 127.0.0.1`

--- a/skeleton/protractor/package.json
+++ b/skeleton/protractor/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "e2e": "au protractor",
-    "e2e:headless": "au protractor --run --start"
+    "e2e": "au protractor --interactive",
+    "e2e:headless": "au protractor --start"
   },
   "devDependencies": {
     // @if feat.typescript

--- a/skeleton/protractor/package.json
+++ b/skeleton/protractor/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "e2e": "au protractor --interactive",
-    "e2e:headless": "au protractor --start"
+    "e2e": "au protractor",
+    "e2e:headless": "au protractor --start --headless"
   },
   "devDependencies": {
     // @if feat.typescript

--- a/skeleton/protractor/protractor.conf.js
+++ b/skeleton/protractor/protractor.conf.js
@@ -8,7 +8,7 @@ Object.assign(cliOptions, {
 
 const port = cliOptions.getFlagValue('port') || aureliaConfig.platform.port;
 const host = cliOptions.getFlagValue('host') || aureliaConfig.platform.host || "localhost";
-const headless = !cliOptions.hasFlag('interactive');
+const headless = cliOptions.hasFlag('headless');
 
 const config  = {
   port: port,

--- a/skeleton/protractor/protractor.conf.js
+++ b/skeleton/protractor/protractor.conf.js
@@ -8,7 +8,7 @@ Object.assign(cliOptions, {
 
 const port = cliOptions.getFlagValue('port') || aureliaConfig.platform.port;
 const host = cliOptions.getFlagValue('host') || aureliaConfig.platform.host || "localhost";
-const headless = cliOptions.hasFlag('run') || false;
+const headless = !cliOptions.hasFlag('interactive');
 
 const config  = {
   port: port,


### PR DESCRIPTION
@3cp, As we have talked before, I changed the `--run` flag to `--interactive` and made the default behavior of e2e test to offline/non-interactive/headless mode, just like what has been done for `karma`.

Please check out the changes and let me know of any concerns.