### PR TITLE
fix(webpack): deal with host option before webpack config

### DIFF
--- a/skeleton/webpack/aurelia_project/tasks/run.ext
+++ b/skeleton/webpack/aurelia_project/tasks/run.ext
@@ -5,6 +5,7 @@ import kill from 'tree-kill';
 // @if feat.typescript
 import * as kill from 'tree-kill';
 // @endif
+import { platform } from '../aurelia.json';
 
 const npm =  new NPM();
 
@@ -17,7 +18,9 @@ function run() {
 // Cleanup --env prod to --env.production
 // for backwards compatibility
 function cleanArgs(args) {
+  let host;
   const cleaned = [];
+
   for (let i = 0, ii = args.length; i < ii; i++) {
     if (args[i] === '--env' && i < ii - 1) {
       const env = args[++i].toLowerCase();
@@ -26,10 +29,17 @@ function cleanArgs(args) {
       } else if (env.startsWith('test')) {
         cleaned.push('--tests');
       }
+    } else if (args[i] === '--host' && i < ii -1) {
+      host = args[++i];
     } else {
       cleaned.push(args[i]);
     }
   }
+
+  // Deal with --host before webpack-dev-server calls webpack config.
+  // Because of https://discourse.aurelia.io/t/changing-platform-host-in-aurelia-json-doesnt-change-the-host-ip/3043/10?u=huochunpeng
+  if (!host) host = platform.host;
+  if (host) cleaned.push('--host', host);
   return cleaned;
 }
 

--- a/skeleton/webpack/webpack.config.js
+++ b/skeleton/webpack/webpack.config.js
@@ -210,7 +210,7 @@ module.exports = ({ production } = {}, {extractCss, analyze, tests, hmr, port, h
     historyApiFallback: true,
     hot: hmr || project.platform.hmr,
     port: port || project.platform.port,
-    host: host || project.platform.host
+    host: host
   },
   devtool: production ? 'nosources-source-map' : 'cheap-module-eval-source-map',
   module: {


### PR DESCRIPTION
Because webpack-dev-server fills up some default value to webpack config. It adds host with value localhost when user didn’t explicitly set in command line. Ref: https://discourse.aurelia.io/t/changing-platform-host-in-aurelia-json-doesnt-change-the-host-ip/3043/10?u=huochunpeng