### PR TITLE
fix(cli-bundler): avoid passing empty source map to concat-with-sourcemaps

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -335,7 +335,7 @@ exports.Bundle = class {
         concat.add(
           currentFile.path ? path.relative(process.cwd(), currentFile.path) : null,
           content,
-          sourceMap ? JSON.stringify(sourceMap) : undefined
+          sourceMap && sourceMap.sources.length ? JSON.stringify(sourceMap) : undefined
         );
       }
 


### PR DESCRIPTION
closes #1157

@kyttike, @arnederuwe it turns out the postcss sourcemap bug can be fixed in our code, by cleaning up the data we send to concat-with-sourcemaps. The #1157 is not a postcss issue, but manifested as the same source map issue.