### PR TITLE
Null reference issue run/watch on scss change

### DIFF
--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -91,7 +91,7 @@ exports.BundledSource = class {
     this.file = file;
     this._contents = null;
     this.requiresTransform = true;
-    this.includedIn.requiresBuild = true;
+    if (this.includedIn) this.includedIn.requiresBuild = true;
   }
 
   transform() {


### PR DESCRIPTION
I have a scenario where bundled scss->css files that are not directly referenced by the aurelia app but are loaded dynamically based on user-selected theme with references to other scss files.  When I do an "au run" and then modify one of these files, which are referenced in the aurelia project json's cssProcess source array glob to trigger rebuild, it does pick up the change, but then the code crashes on rebuild due to a null reference.  I dug in and the issue turns out to be this.includedIn in the bundled-source.js file update(file) method.  Doing a simple null check fixes everything for my scenario.