### PR TITLE
refactor(webpack): cleanup promise-polyfill, aurelia-dialog patch for IE11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-cli",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/skeleton/protractor/protractor.conf.js
+++ b/skeleton/protractor/protractor.conf.js
@@ -78,6 +78,8 @@ const config  = {
 if (headless) {
   config.capabilities.chromeOptions.args.push("--no-gpu");
   config.capabilities.chromeOptions.args.push("--headless");
+  config.capabilities.chromeOptions.args.push("--no-sandbox");
+  config.capabilities.chromeOptions.args.push("--disable-dev-shm-usage");
 }
 
 exports.config = config;

--- a/skeleton/webpack/webpack.config.js
+++ b/skeleton/webpack/webpack.config.js
@@ -5,7 +5,9 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
 const project = require('./aurelia_project/aurelia.json');
 const { AureliaPlugin, ModuleDependenciesPlugin } = require('aurelia-webpack-plugin');
+// @if feat['scaffold-navigation']
 const { ProvidePlugin } = require('webpack');
+// @endif
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 
@@ -67,7 +69,11 @@ module.exports = ({ production } = {}, {extractCss, analyze, tests, hmr, port, h
     alias: { 'aurelia-binding': path.resolve(__dirname, 'node_modules/aurelia-binding') }
   },
   entry: {
-    app: ['aurelia-bootstrapper']
+    app: [
+      // Remove next line if you don't need to support IE11
+      'promise-polyfill/src/polyfill',
+      'aurelia-bootstrapper'
+    ]
   },
   mode: production ? 'production' : 'development',
   output: {
@@ -310,13 +316,14 @@ module.exports = ({ production } = {}, {extractCss, analyze, tests, hmr, port, h
   plugins: [
     ...when(!tests, new DuplicatePackageCheckerPlugin()),
     new AureliaPlugin(),
-    new ProvidePlugin({
     // @if feat['scaffold-navigation']
-      $: 'jquery',
-      jQuery: 'jquery',
-    // @endif
-      'Promise': ['promise-polyfill', 'default']
+    new ProvidePlugin({
+      'jQuery': 'jquery',
+      '$': 'jquery',
+      'window.jQuery': 'jquery',
+      'window.$': 'jquery'
     }),
+    // @endif
     new ModuleDependenciesPlugin({
       'aurelia-testing': ['./compile-spy', './view-spy']
     }),

--- a/skeleton/webpack/webpack.config.js
+++ b/skeleton/webpack/webpack.config.js
@@ -64,9 +64,17 @@ module.exports = ({ production } = {}, {extractCss, analyze, tests, hmr, port, h
     extensions: ['.js'],
     // @endif
     modules: [srcDir, 'node_modules'],
-    // Enforce single aurelia-binding, to avoid v1/v2 duplication due to
-    // out-of-date dependencies on 3rd party aurelia plugins
-    alias: { 'aurelia-binding': path.resolve(__dirname, 'node_modules/aurelia-binding') }
+
+    alias: {
+      // https://github.com/aurelia/dialog/issues/387
+      // Uncomment next line if you want to use aurelia-dialog on IE11
+      // 'aurelia-dialog': path.resolve(__dirname, 'node_modules/aurelia-dialog/dist/umd/aurelia-dialog.js'),
+
+      // https://github.com/aurelia/binding/issues/702
+      // Enforce single aurelia-binding, to avoid v1/v2 duplication due to
+      // out-of-date dependencies on 3rd party aurelia plugins
+      'aurelia-binding': path.resolve(__dirname, 'node_modules/aurelia-binding')
+    }
   },
   entry: {
     app: [


### PR DESCRIPTION
Move promise-polyfill from ProviderPlugin to entry.
Add aurelia-dialog patch for IE11, but user needs to uncomment it.

Closes aurelia/dialog#387