### PR TITLE
fixed(protractor): fixes chrome-driver running inside container

### DIFF
--- a/skeleton/protractor/protractor.conf.js
+++ b/skeleton/protractor/protractor.conf.js
@@ -78,6 +78,8 @@ const config  = {
 if (headless) {
   config.capabilities.chromeOptions.args.push("--no-gpu");
   config.capabilities.chromeOptions.args.push("--headless");
+  config.capabilities.chromeOptions.args.push("--no-sandbox");
+  config.capabilities.chromeOptions.args.push("--disable-dev-shm-usage");
 }
 
 exports.config = config;


### PR DESCRIPTION
When running chrome-driver via protractor it fails with `DevToolsActivePort file doesn't exist`, two arguments should be passed to chrome based on the discussions [here](https://github.com/puppeteer/puppeteer/issues/1834), [here](https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t), and [here](https://github.com/SeleniumHQ/selenium/issues/6049#issuecomment-398867205)