### PR TITLE
Update webpack.netcore.config.js__skip-if-exists__if_webpack

### DIFF
--- a/skeleton/dotnet-core/webpack.netcore.config.js__skip-if-exists__if_webpack
+++ b/skeleton/dotnet-core/webpack.netcore.config.js__skip-if-exists__if_webpack
@@ -21,7 +21,7 @@ module.exports = () => {
   });
   config.plugins = [
     // first clean the output directory
-    new CleanWebpackPlugin([config.output.path]),
+    new CleanWebpackPlugin(),
     ...config.plugins
   ];
 


### PR DESCRIPTION
remove output Path from CleanWebpackPlugin. Default Webpack output path is sufficient. Because after creating a new Aurelia Project with "au new" the application isn't able to run, because CleanWebpackPlugin doesn't accept the config output path parameter which is set on Line 24