### PR TITLE
feat: replace bin name "au" with "au1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 This library is part of the [Aurelia](http://www.aurelia.io/) platform and contains its CLI implementation.
 To keep up to date on [Aurelia](http://www.aurelia.io/), please visit and subscribe to [the official blog](http://blog.aurelia.io/) and [our email list](http://eepurl.com/ces50j). We also invite you to [follow us on twitter](https://twitter.com/aureliaeffect). If you have questions look around our [Discourse forums](https://discourse.aurelia.io/), chat in our [community on Gitter](https://gitter.im/aurelia/discuss) or use [stack overflow](http://stackoverflow.com/search?q=aurelia). Documentation can be found [in our developer hub](http://aurelia.io/docs).
 
+** Aurelia CLI v2 has deprecated bin name "au", replaced it with "au1".** We decided to reserve bin name "au" for upcoming Aurelia 2. More to come ...
+
 ## Documentation
 
 You can read documentation on the cli [here](https://aurelia.io/docs/cli). If you would like to help improve this documentation, visit [aurelia/documentation](https://github.com/aurelia/documentation/tree/master/current/en-us/11.%20cli).
@@ -27,8 +29,8 @@ App skeleton has been moved to a dedicated repo [aurelia/v1](https://github.com/
 3. Run `npm install`
 4. Run build `npm run build`
 5. Link the cli with: `npm link`
-6. Create a new project with `au new` or use an existing project. The linked CLI will be used to create the project.
-7. In the project directory, run `npm link aurelia-cli`. The linked CLI will then be used for `au` commands such as `au run`
+6. Create a new project with `au1 new` or use an existing project. The linked CLI will be used to create the project.
+7. In the project directory, run `npm link aurelia-cli`. The linked CLI will then be used for `au1` commands such as `au1 run`
 
 ## Running the Tests
 

--- a/bin/deprecated-au.js
+++ b/bin/deprecated-au.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const c = require('ansi-colors');
+const args = process.argv.slice(2);
+
+console.log(c.yellow(`DEPRECATED: ${c.bgYellow.black(' au ')} has been deprecated in aurelia-cli v2. Plese use ${c.bgYellow.black(` ${['au1', ...args].join(' ')} `)} instead.`));
+console.log(`We decided to reserve bin name ${c.bgWhite.black(' au ')} for upcoming Aurelia 2. More to come ...`);
+process.exit(1);

--- a/lib/project-item.js
+++ b/lib/project-item.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('./file-system');
 const Utils = require('./build/utils');
 
-// Legacy code, kept only for supporting `au generate`
+// Legacy code, kept only for supporting `au1 generate`
 exports.ProjectItem = class {
   constructor(name, isDirectory) {
     this.name = name;

--- a/lib/project.js
+++ b/lib/project.js
@@ -37,7 +37,7 @@ exports.Project = class {
   }
 
   // Legacy code. This code and those ProjectItem.directory above, were kept only
-  // for supporting `au generate`
+  // for supporting `au1 generate`
   commitChanges() {
     return Promise.all(this.locations.map(x => x.create(this.directory)));
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "bin": {
     "aurelia": "bin/aurelia-cli.js",
-    "au": "bin/aurelia-cli.js"
+    "au1": "bin/aurelia-cli.js",
+    "au": "bin/deprecated-au.js"
   },
   "engines": {
     "node": ">=10.12.0"


### PR DESCRIPTION
"au xxx" now prints out a deprecation warning. It will be totally removed before releasing Aurelia 2 CLI.

BREAKING CHANGE: bin name "au" is deprecated and reserved for Aurelia 2 CLI.