### PR TITLE
chore(Deps): bumped Gulp to 5.0.0 and Nodemon to 3.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "enquirer": "^2.3.6",
     "events": "^3.3.0",
     "fs-browser-stub": "^1.0.1",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.0",
     "htmlparser2": "^8.0.1",
     "https-browserify": "^1.0.0",
     "lodash": "^4.17.21",
@@ -93,7 +93,7 @@
     "eslint": "^8.17.0",
     "jasmine": "^4.1.0",
     "jasmine-spec-reporter": "^7.0.0",
-    "nodemon": "^2.0.16",
+    "nodemon": "^3.1.4",
     "nyc": "^15.1.0",
     "standard-changelog": "^2.0.27",
     "yargs": "^17.5.1"


### PR DESCRIPTION
Hi there, 

I've noticed 17 vulnerabilities in sub-deps. The two concerned dependencies are Nodemon and Gulp.
This PR bumps them to the following:
- Gulp to 5.0.0
- Nodemon to 3.1.4

I've tested post update and saw no issues.

This clears any vulnerabilities.
Could we bump a fix version for this to allow consumers apps to take advantage of it?
Thanks!