### PR TITLE
fix: source maps for ES modules have wrong offsets after conversion to AMD (#1214)

### DIFF
--- a/lib/build/amodro-trace/read/es.js
+++ b/lib/build/amodro-trace/read/es.js
@@ -1,9 +1,16 @@
-const transform = require('@babel/core').transform;
+const transformSync = require('@babel/core').transformSync;
 
-// use babel to translate native es module into AMD module
-module.exports = function es(fileName, fileContents) {
-  return transform(fileContents, {
+/**
+ * Use babel to translate native es module into AMD module
+ * @param {string} fileName 
+ * @param {string} fileContents 
+ * @param {{} | boolean} inputSourceMap 
+ * @returns {{ code: string, map: string, ast: any }}
+ */
+module.exports = function es(fileName, fileContents, inputSourceMap) {
+  return transformSync(fileContents, {
     babelrc: false,
-    plugins: [['@babel/plugin-transform-modules-amd', {loose: true}]]
-  }).code;
+    plugins: [['@babel/plugin-transform-modules-amd', {loose: true}]],
+    inputSourceMap: inputSourceMap
+  });
 };

--- a/lib/build/bundled-source.js
+++ b/lib/build/bundled-source.js
@@ -230,7 +230,17 @@ exports.BundledSource = class {
         } catch {
           // file is not in amd/cjs format, try native es module
           try {
-            contents = esTransform(modulePath, this.contents);
+            /** @type {{} | boolean} */
+            let inputSourceMap = false;
+            if (this.file.sourceMap) {
+              inputSourceMap = typeof this.file.sourceMap === 'string' ? JSON.parse(this.file.sourceMap) : this.file.sourceMap;
+            }
+            const result = esTransform(modulePath, this.contents, inputSourceMap);
+
+            contents = result.code;
+            if (result.map) {
+              this.file.sourceMap = result.map; // save updated source map
+            }
           } catch (e) {
             logger.error('Could not convert to AMD module, skipping ' + modulePath);
             logger.error('Error was: ' + e);


### PR DESCRIPTION
Fixes issue with ES module source maps, after conversion to AMD. Described here #1214.